### PR TITLE
fix: add users api reference to the docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       - 3006:3001
     networks:
       - vfd-network
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    environment:
+      - NEXT_PUBLIC_USERS_API_BASE_URL=${NEXT_PUBLIC_USERS_API_BASE_URL:-http://host.docker.internal:5001}
     labels:
       - traefik.enable=true
       - traefik.http.routers.virtual-finland-mvp.rule=Host(`virtual-finland.localhost`)


### PR DESCRIPTION
In local development setup: when running as/with nextjs-backend the dockerized server-to-server connection fails to resolve to the correct docker-host address. The addresses that are directly used with browser do resolve just fine as browser is in the localhost-accessible network, but the backend server runs in dockerized host and as such fails in routing. 

- add docker-compose reference for the users api