### PR TITLE
a11y improvements v2

### DIFF
--- a/apps/vf-features/__tests__/working.profile.page.test.tsx
+++ b/apps/vf-features/__tests__/working.profile.page.test.tsx
@@ -59,7 +59,13 @@ describe('Personal profile page', () => {
     ).toBeInTheDocument();
     // n selected occupations button should appear in modal
     const nSelectedButton = screen.getByRole('button', {
-      name: `(${MOCK_JOB_APPLICANT_INFO.occupations.length}) Selected`,
+      name: content => {
+        const subStrings = [
+          `(${MOCK_JOB_APPLICANT_INFO.occupations.length})`,
+          'Selected',
+        ];
+        return subStrings.every(s => content.includes(s));
+      },
     });
     expect(nSelectedButton).toBeInTheDocument();
     // click the above button, takes user to edit phase of selected occupations

--- a/apps/vf-features/src/pages/_document.page.tsx
+++ b/apps/vf-features/src/pages/_document.page.tsx
@@ -44,6 +44,10 @@ import { ServerStyleSheet } from 'styled-components';
         <body>
           <Main />
           <NextScript />
+          <noscript>
+            Sorry, this site doesn’t work properly because your device/browser
+            does not support JavaScript.
+          </noscript>
         </body>
       </Html>
     );

--- a/apps/vf-mvp/__tests__/working.profile.page.test.tsx
+++ b/apps/vf-mvp/__tests__/working.profile.page.test.tsx
@@ -59,7 +59,13 @@ describe('Personal profile page', () => {
     ).toBeInTheDocument();
     // n selected occupations button should appear in modal
     const nSelectedButton = screen.getByRole('button', {
-      name: `(${MOCK_JOB_APPLICANT_INFO.occupations.length}) Selected`,
+      name: content => {
+        const subStrings = [
+          `(${MOCK_JOB_APPLICANT_INFO.occupations.length})`,
+          'Selected',
+        ];
+        return subStrings.every(s => content.includes(s));
+      },
     });
     expect(nSelectedButton).toBeInTheDocument();
     // click the above button, takes user to edit phase of selected occupations

--- a/apps/vf-mvp/src/pages/_document.page.tsx
+++ b/apps/vf-mvp/src/pages/_document.page.tsx
@@ -44,6 +44,10 @@ import { ServerStyleSheet } from 'styled-components';
         <body>
           <Main />
           <NextScript />
+          <noscript>
+            Sorry, this site doesn’t work properly because your device/browser
+            does not support JavaScript.
+          </noscript>
         </body>
       </Html>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/lodash.groupby": "^4.6.7",
         "@types/lodash.merge": "^4.6.7",
         "@types/react-highlight-words": "^0.16.4",
+        "@types/styled-components": "^5.1.26",
         "axios": "^1.3.6",
         "cookie": "^0.5.0",
         "date-fns": "^2.29.3",
@@ -3411,6 +3412,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true,
@@ -3603,6 +3613,16 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/styled-components": {
+      "version": "5.1.26",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.26.tgz",
+      "integrity": "sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.5",
@@ -16636,6 +16656,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true
@@ -16796,6 +16825,16 @@
     "@types/stack-utils": {
       "version": "2.0.1",
       "dev": true
+    },
+    "@types/styled-components": {
+      "version": "5.1.26",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.26.tgz",
+      "integrity": "sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==",
+      "requires": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "@types/testing-library__jest-dom": {
       "version": "5.14.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "pdfjs-dist": "^3.5.141",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-focus-lock": "^2.9.4",
         "react-highlight-words": "^0.20.0",
         "react-hook-form": "^7.43.9",
         "react-icons": "^4.8.0",
@@ -5507,6 +5508,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "dev": true,
@@ -6759,6 +6765,17 @@
       "version": "3.2.7",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/focus-lock": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -11667,6 +11684,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
@@ -11682,6 +11710,28 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
+      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-highlight-words": {
       "version": "0.20.0",
@@ -13471,6 +13521,47 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -17848,6 +17939,11 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "didyoumean": {
       "version": "1.2.2",
       "dev": true
@@ -18688,6 +18784,14 @@
     "flatted": {
       "version": "3.2.7",
       "dev": true
+    },
+    "focus-lock": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
     },
     "follow-redirects": {
       "version": "1.15.2"
@@ -21842,6 +21946,14 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "requires": {
+        "@babel/runtime": "^7.12.13"
+      }
+    },
     "react-dom": {
       "version": "18.2.0",
       "requires": {
@@ -21853,6 +21965,19 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "react-focus-lock": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
+      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      }
     },
     "react-highlight-words": {
       "version": "0.20.0",
@@ -22969,6 +23094,23 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
       }
     },
     "use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "pdfjs-dist": "^3.5.141",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-focus-lock": "^2.9.4",
     "react-highlight-words": "^0.20.0",
     "react-hook-form": "^7.43.9",
     "react-icons": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/lodash.groupby": "^4.6.7",
     "@types/lodash.merge": "^4.6.7",
     "@types/react-highlight-words": "^0.16.4",
+    "@types/styled-components": "^5.1.26",
     "axios": "^1.3.6",
     "cookie": "^0.5.0",
     "date-fns": "^2.29.3",

--- a/packages/vf-shared/src/components/form/form-input.tsx
+++ b/packages/vf-shared/src/components/form/form-input.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import {
   Control,
   Controller,
@@ -16,12 +17,13 @@ interface FormInputControllerProps<T extends FieldValues> {
 }
 
 interface Props<T extends FieldValues> extends FormInputControllerProps<T> {
-  labelText: string;
+  labelText: ReactNode;
   hintText?: string;
   optionalText?: string;
-  placeholder?: string;
+  placeholder?: ReactNode;
   showStatusText?: boolean;
   readOnly?: boolean;
+  autoFocus?: boolean;
   type?:
     | 'number'
     | 'text'
@@ -50,6 +52,7 @@ export default function FormInput<T extends FieldValues>(props: Props<T>) {
     formatDefaultValue,
     min = 1,
     step = 1,
+    autoFocus,
   } = props;
 
   const { width } = useDimensions();
@@ -115,6 +118,8 @@ export default function FormInput<T extends FieldValues>(props: Props<T>) {
               min={min}
               step={step}
               readOnly={readOnly}
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus={autoFocus}
             />
           )}
         </>

--- a/packages/vf-shared/src/components/form/form-multi-select.tsx
+++ b/packages/vf-shared/src/components/form/form-multi-select.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import {
   Control,
   Controller,
@@ -28,7 +29,7 @@ interface SelectInputControllerProps<T extends FieldValues> {
 }
 
 interface Props<T extends FieldValues> extends SelectInputControllerProps<T> {
-  labelText: string;
+  labelText: ReactNode;
   hintText?: string;
   optionalText?: string;
   showStatusText?: boolean;

--- a/packages/vf-shared/src/components/form/form-phone-input.tsx
+++ b/packages/vf-shared/src/components/form/form-phone-input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { ReactNode, forwardRef } from 'react';
 import {
   Control,
   FieldError,
@@ -17,7 +17,7 @@ interface PhoneInputControllerProps<T extends FieldValues> {
 }
 
 interface Props<T extends FieldValues> extends PhoneInputControllerProps<T> {
-  labelText: string;
+  labelText: ReactNode;
   hintText?: string;
   optionalText?: string;
   error?: FieldError | undefined;

--- a/packages/vf-shared/src/components/form/form-single-select.tsx
+++ b/packages/vf-shared/src/components/form/form-single-select.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import {
   Control,
   Controller,
@@ -14,11 +15,12 @@ interface SelectInputControllerProps<T extends FieldValues> {
 }
 
 interface Props<T extends FieldValues> extends SelectInputControllerProps<T> {
-  labelText: string;
+  labelText: ReactNode;
   hintText?: string;
   optionalText?: string;
   showStatusText?: boolean;
   items: { labelText: string; uniqueItemId: string; disabled?: boolean }[];
+  autoFocus?: boolean;
 }
 
 export default function FormSingleSelect<T extends FieldValues>(

--- a/packages/vf-shared/src/components/layout/main-navigation.tsx
+++ b/packages/vf-shared/src/components/layout/main-navigation.tsx
@@ -23,7 +23,7 @@ import CustomLink from '../ui/custom-link';
 const MobileMenuToggleButton = styled(Button).attrs({
   variant: 'secondaryNoBorder',
   className: '!p-0 !px-2',
-  'aria-label': 'menu toggle button',
+  'aria-label': 'Toggle menu button',
 })`
   &:hover {
     background: transparent !important;

--- a/packages/vf-shared/src/components/layout/main-navigation.tsx
+++ b/packages/vf-shared/src/components/layout/main-navigation.tsx
@@ -83,11 +83,9 @@ function DesktopMenuPopover({
                 <>
                   <IconFileCabinet className="flex-shrink-0 h-12 w-12" />
                   <div className="flex flex-col">
-                    <button className="flex" onClick={() => close()}>
-                      <CustomLink href={item.href} $bold>
-                        {item.name}
-                      </CustomLink>
-                    </button>
+                    <CustomLink href={item.href} $bold onClick={() => close()}>
+                      {item.name}
+                    </CustomLink>
                     <Text>Page info here.</Text>
                   </div>
                 </>

--- a/packages/vf-shared/src/components/layout/main-navigation.tsx
+++ b/packages/vf-shared/src/components/layout/main-navigation.tsx
@@ -46,11 +46,12 @@ function MobileLink({ onClick, children, href }: MobileLink) {
   );
 }
 
-const DesktopNavItem = styled.li.attrs<{ isActive: boolean }>(
-  ({ isActive }) => ({
+const DesktopNavItem = styled(Link).attrs<{ isActive: boolean }>(
+  ({ isActive, href }) => ({
     className: `border-b-4 py-2 px-4 mx-7 hover:border-b-suomifi-light cursor-pointer ${
       isActive ? 'border-b-suomifi-light' : 'border-b-transparent'
     }`,
+    href,
   })
 )<{ isActive: boolean }>`
   a {
@@ -104,7 +105,7 @@ function DesktopNavigation({ navigationItems }: { navigationItems: NavItems }) {
   return (
     <div className="hidden md:block border-t border-t-gray-300">
       <div className="container px-4">
-        <ul className="hidden md:flex flex-wrap gap-4 -mx-7">
+        <nav className="hidden md:flex flex-wrap gap-4 -mx-7">
           {navigationItems.map(item => (
             <DesktopNavItem
               key={item.name}
@@ -112,12 +113,12 @@ function DesktopNavigation({ navigationItems }: { navigationItems: NavItems }) {
                 (item.href === '/' && router.pathname === item.href) ||
                 (item.href !== '/' && router.pathname.includes(item.href))
               }
-              onClick={() => router.push(item.href)}
+              href={item.href}
             >
               <Text>{item.name}</Text>
             </DesktopNavItem>
           ))}
-        </ul>
+        </nav>
       </div>
     </div>
   );

--- a/packages/vf-shared/src/components/layout/main-navigation.tsx
+++ b/packages/vf-shared/src/components/layout/main-navigation.tsx
@@ -46,18 +46,15 @@ function MobileLink({ onClick, children, href }: MobileLink) {
   );
 }
 
-const DesktopNavItem = styled(Link).attrs<{ isActive: boolean }>(
-  ({ $isActive, href }) => ({
-    className: `border-b-4 py-2 px-4 mx-7 hover:border-b-suomifi-light cursor-pointer ${
-      $isActive ? 'border-b-suomifi-light' : 'border-b-transparent'
-    }`,
-    href,
-  })
-)<{ isActive: boolean }>`
-  a {
-    font-weight: 700;
-  }
-`;
+const DesktopNavItem = styled(Link).attrs<{
+  $isActive: boolean;
+  href: boolean;
+}>(({ $isActive, href }) => ({
+  className: `border-b-4 py-2 px-4 mx-7 hover:border-b-suomifi-light cursor-pointer ${
+    $isActive ? 'border-b-suomifi-light' : 'border-b-transparent'
+  }`,
+  href,
+}))<{ $isActive: boolean }>``;
 
 function DesktopMenuPopover({
   navigationItems,

--- a/packages/vf-shared/src/components/layout/main-navigation.tsx
+++ b/packages/vf-shared/src/components/layout/main-navigation.tsx
@@ -47,9 +47,9 @@ function MobileLink({ onClick, children, href }: MobileLink) {
 }
 
 const DesktopNavItem = styled(Link).attrs<{ isActive: boolean }>(
-  ({ isActive, href }) => ({
+  ({ $isActive, href }) => ({
     className: `border-b-4 py-2 px-4 mx-7 hover:border-b-suomifi-light cursor-pointer ${
-      isActive ? 'border-b-suomifi-light' : 'border-b-transparent'
+      $isActive ? 'border-b-suomifi-light' : 'border-b-transparent'
     }`,
     href,
   })
@@ -109,7 +109,7 @@ function DesktopNavigation({ navigationItems }: { navigationItems: NavItems }) {
           {navigationItems.map(item => (
             <DesktopNavItem
               key={item.name}
-              isActive={
+              $isActive={
                 (item.href === '/' && router.pathname === item.href) ||
                 (item.href !== '/' && router.pathname.includes(item.href))
               }

--- a/packages/vf-shared/src/components/pages/profile/certifications-select/certifications-edit.tsx
+++ b/packages/vf-shared/src/components/pages/profile/certifications-select/certifications-edit.tsx
@@ -29,9 +29,11 @@ const DEFAULT_VALUE: Certification = {
 export default function CertificationsEdit(props: Props) {
   const { userCertifications, escoSkills, onSave, onClose } = props;
 
-  const { handleSubmit, control } = useForm<FormProps>({
+  const { handleSubmit, control, watch } = useForm<FormProps>({
     defaultValues: { certifications: userCertifications },
   });
+
+  const certifications = watch('certifications');
 
   const { fields, append, remove } = useFieldArray<FormProps>({
     control,
@@ -47,63 +49,92 @@ export default function CertificationsEdit(props: Props) {
       <div className="flex flex-col gap-3">
         {!fields.length && <Text>No certifications added.</Text>}
 
-        {fields.map((field, index) => (
-          <div
-            key={field.id}
-            className="flex flex-col gap-3 items-start border-b border-gray-300 pb-4"
-          >
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 items-end">
-              <FormInput
-                name={`certifications.${index}.certificationName`}
-                control={control}
-                rules={{ required: true }}
-                labelText="Certification name"
-              />
-              <FormInput
-                name={`certifications.${index}.institutionName`}
-                control={control}
-                rules={{ required: true }}
-                labelText="Institution name"
-              />
-            </div>
-            <Controller
-              name={`certifications.${index}.escoIdentifier`}
-              control={control}
-              render={({ field: { onChange, value } }) => (
-                <MoreRecommendations
-                  type="skills"
-                  onSelect={(
-                    selected: {
-                      labelText: string;
-                      uniqueItemId: string;
-                    }[]
-                  ) => onChange(selected.map(s => s.uniqueItemId))}
-                  defaultValue={value.map(escoIdentifier => {
-                    const escoIndex = escoSkills.findIndex(
-                      skill => skill.uri === escoIdentifier
-                    );
-                    return {
-                      labelText:
-                        escoIndex > -1
-                          ? escoSkills[escoIndex].prefLabel.en
-                          : escoIdentifier,
-                      uniqueItemId: escoIdentifier,
-                    };
-                  })}
-                />
-              )}
-            />
+        {fields.map((field, index) => {
+          const certificationName = certifications[index]?.certificationName;
 
-            <Button
-              variant="link"
-              iconRight={<IconRemove />}
-              className="!mt-3"
-              onClick={() => remove(index)}
+          return (
+            <div
+              key={field.id}
+              className="flex flex-col gap-3 items-start border-b border-gray-300 pb-4"
             >
-              Remove
-            </Button>
-          </div>
-        ))}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 items-end">
+                <FormInput
+                  name={`certifications.${index}.certificationName`}
+                  control={control}
+                  rules={{ required: true }}
+                  labelText="Certification name"
+                  // have the input autofocus, when new field is added
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus={index === fields.length - 1}
+                />
+                <FormInput
+                  name={`certifications.${index}.institutionName`}
+                  control={control}
+                  rules={{ required: true }}
+                  labelText={
+                    <>
+                      Institution name{' '}
+                      {certificationName && (
+                        <span className="sr-only">
+                          for {certificationName} certification
+                        </span>
+                      )}
+                    </>
+                  }
+                />
+              </div>
+              <Controller
+                name={`certifications.${index}.escoIdentifier`}
+                control={control}
+                render={({ field: { onChange, value } }) => (
+                  <MoreRecommendations
+                    type="skills"
+                    labelText={
+                      <>
+                        Select related skills{' '}
+                        {certificationName && (
+                          <span className="sr-only">
+                            for {certificationName}
+                          </span>
+                        )}
+                      </>
+                    }
+                    onSelect={(
+                      selected: {
+                        labelText: string;
+                        uniqueItemId: string;
+                      }[]
+                    ) => onChange(selected.map(s => s.uniqueItemId))}
+                    defaultValue={value.map(escoIdentifier => {
+                      const escoIndex = escoSkills.findIndex(
+                        skill => skill.uri === escoIdentifier
+                      );
+                      return {
+                        labelText:
+                          escoIndex > -1
+                            ? escoSkills[escoIndex].prefLabel.en
+                            : escoIdentifier,
+                        uniqueItemId: escoIdentifier,
+                      };
+                    })}
+                  />
+                )}
+              />
+
+              <Button
+                variant="link"
+                iconRight={<IconRemove />}
+                className="!mt-3"
+                onClick={() => remove(index)}
+              >
+                Remove{' '}
+                <span className="sr-only">
+                  {certificationName || 'certification'}
+                </span>
+              </Button>
+            </div>
+          );
+        })}
       </div>
 
       <div className="mt-4">
@@ -112,7 +143,7 @@ export default function CertificationsEdit(props: Props) {
           iconRight={<IconPlus />}
           onClick={() => append(DEFAULT_VALUE)}
         >
-          Add new
+          Add new <span className="sr-only">certification</span>
         </Button>
       </div>
 

--- a/packages/vf-shared/src/components/pages/profile/educations-select/educations-edit.tsx
+++ b/packages/vf-shared/src/components/pages/profile/educations-select/educations-edit.tsx
@@ -28,13 +28,15 @@ export default function EducationsEdit(props: Props) {
   const { userEducations, educationFields, educationLevels, onSave, onClose } =
     props;
 
-  const { handleSubmit, control } = useForm<FormProps>({
+  const { handleSubmit, control, watch } = useForm<FormProps>({
     defaultValues: userEducations
       ? { educations: userEducations }
       : {
           educations: [DEFAULT_VALUE],
         },
   });
+
+  const educations = watch('educations');
 
   const { fields, append, remove } = useFieldArray<FormProps>({
     control,
@@ -50,64 +52,110 @@ export default function EducationsEdit(props: Props) {
       <div className="flex flex-col gap-4">
         {!fields.length && <Text>No educations added.</Text>}
 
-        {fields.map((field, index) => (
-          <div key={field.id} className="border-b border-gray-300 pb-4">
-            <div className="grid sm:grid-cols-2 gap-3 items-end">
-              <FormInput
-                name={`educations.${index}.educationName`}
-                control={control}
-                rules={{ required: true }}
-                labelText="Education name"
-              />
-              <FormInput
-                name={`educations.${index}.institutionName`}
-                control={control}
-                rules={{ required: true }}
-                labelText="Institution name"
-              />
-            </div>
-            <div className="grid sm:grid-cols-2 gap-3 items-end mt-3">
-              <FormSingleSelect
-                name={`educations.${index}.educationField`}
-                control={control}
-                rules={{ required: true }}
-                labelText="Education field"
-                items={educationFields.map(f => ({
-                  labelText: f.prefLabel.fi,
-                  uniqueItemId: f.codeValue,
-                }))}
-              />
-              <FormSingleSelect
-                name={`educations.${index}.educationLevel`}
-                control={control}
-                rules={{ required: true }}
-                labelText="Skill level"
-                items={educationLevels.map(l => ({
-                  labelText: l.prefLabel.en,
-                  uniqueItemId: l.codeValue,
-                }))}
-              />
-            </div>
-            <div className="grid md:grid-cols-2 gap-3 items-end mt-3">
-              <FormInput
-                type="date"
-                name={`educations.${index}.graduationDate`}
-                control={control}
-                rules={{ required: true }}
-                labelText="Graduation date"
-              />
-              <div>
-                <Button
-                  variant="link"
-                  iconRight={<IconRemove />}
-                  onClick={() => remove(index)}
-                >
-                  Remove
-                </Button>
+        {fields.map((field, index) => {
+          const educationName = educations[index]?.educationName;
+
+          return (
+            <div key={field.id} className="border-b border-gray-300 pb-4">
+              <div className="grid sm:grid-cols-2 gap-3 items-end">
+                <FormInput
+                  name={`educations.${index}.educationName`}
+                  control={control}
+                  rules={{ required: true }}
+                  labelText="Education name"
+                  // have the input autofocus, when new field is added
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus={index === fields.length - 1}
+                />
+                <FormInput
+                  name={`educations.${index}.institutionName`}
+                  control={control}
+                  rules={{ required: true }}
+                  labelText={
+                    <>
+                      Institution name{' '}
+                      {educationName && (
+                        <span className="sr-only">
+                          for {educationName} education
+                        </span>
+                      )}
+                    </>
+                  }
+                />
+              </div>
+              <div className="grid sm:grid-cols-2 gap-3 items-end mt-3">
+                <FormSingleSelect
+                  name={`educations.${index}.educationField`}
+                  control={control}
+                  rules={{ required: true }}
+                  labelText={
+                    <>
+                      Education field{' '}
+                      {educationName && (
+                        <span className="sr-only">
+                          for {educationName} education
+                        </span>
+                      )}
+                    </>
+                  }
+                  items={educationFields.map(f => ({
+                    labelText: f.prefLabel.fi,
+                    uniqueItemId: f.codeValue,
+                  }))}
+                />
+                <FormSingleSelect
+                  name={`educations.${index}.educationLevel`}
+                  control={control}
+                  rules={{ required: true }}
+                  labelText={
+                    <>
+                      Skill level{' '}
+                      {educationName && (
+                        <span className="sr-only">
+                          for {educationName} education
+                        </span>
+                      )}
+                    </>
+                  }
+                  items={educationLevels.map(l => ({
+                    labelText: l.prefLabel.en,
+                    uniqueItemId: l.codeValue,
+                  }))}
+                />
+              </div>
+              <div className="grid md:grid-cols-2 gap-3 items-end mt-3">
+                <FormInput
+                  type="date"
+                  name={`educations.${index}.graduationDate`}
+                  control={control}
+                  rules={{ required: true }}
+                  labelText={
+                    <>
+                      Graduation date{' '}
+                      {educationName && (
+                        <span className="sr-only">
+                          for {educationName} education
+                        </span>
+                      )}
+                    </>
+                  }
+                />
+                <div>
+                  <Button
+                    variant="link"
+                    iconRight={<IconRemove />}
+                    onClick={() => remove(index)}
+                  >
+                    Remove{' '}
+                    <span className="sr-only">
+                      {educationName || ''} education
+                    </span>
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
       <div className="mt-4">
         <Button
@@ -115,7 +163,7 @@ export default function EducationsEdit(props: Props) {
           iconRight={<IconPlus />}
           onClick={() => append(DEFAULT_VALUE)}
         >
-          Add new
+          Add new <span className="sr-only">education</span>
         </Button>
       </div>
       <div className="flex flex-row gap-3 mt-8">

--- a/packages/vf-shared/src/components/pages/profile/industry-select/industry-edit.tsx
+++ b/packages/vf-shared/src/components/pages/profile/industry-select/industry-edit.tsx
@@ -153,13 +153,14 @@ export default function IndustryEdit(props: Props) {
               className="flex flex-row items-center gap-2 bg-suomifi-light hover:bg-suomifi-light-hover text-white font-bold rounded-xl px-2"
               type="button"
               onClick={() => setSelected(undefined)}
+              aria-label="Remove selected industry"
             >
               <span>{selected.prefLabel.en}</span>
               <IoClose
                 className="flex-shrink-0"
                 role="button"
-                tabIndex={0}
-                aria-label="Remove selected industry"
+                focusable={false}
+                aria-hidden="true"
               />
             </button>
           </div>

--- a/packages/vf-shared/src/components/pages/profile/jmf-recommendations/jmf-recommendations.tsx
+++ b/packages/vf-shared/src/components/pages/profile/jmf-recommendations/jmf-recommendations.tsx
@@ -177,7 +177,7 @@ export default function JmfRecommendationsSelect(
           </CustomHeading>
           <Textarea
             className="!w-full"
-            labelText="You will get keyword suggestions based on your text. Please choose the most suitable ones. You can also upload a text file or your CV (PDF)."
+            labelText="Add keywords for search. You will get keyword suggestions based on your text. Please choose the most suitable ones. You can also upload a text file or your CV (PDF)."
             hintText=""
             visualPlaceholder={
               selectedFileName ? `Using upload: ${selectedFileName}` : ''

--- a/packages/vf-shared/src/components/pages/profile/jmf-recommendations/more-recommendations.tsx
+++ b/packages/vf-shared/src/components/pages/profile/jmf-recommendations/more-recommendations.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { IoClose } from 'react-icons/io5';
 import lodash_debounce from 'lodash.debounce';
 import { MultiSelect, Text } from 'suomifi-ui-components';
@@ -13,6 +13,7 @@ interface Props {
   onSelect: (selected: any) => void;
   defaultValue: SelectionItem[];
   showCustomChipList?: boolean;
+  labelText?: ReactNode;
 }
 
 const CustomChipItem = ({
@@ -40,7 +41,13 @@ const CustomChipItem = ({
 };
 
 export default function MoreRecommendations(props: Props) {
-  const { type, onSelect, defaultValue, showCustomChipList = true } = props;
+  const {
+    type,
+    onSelect,
+    defaultValue,
+    showCustomChipList = true,
+    labelText,
+  } = props;
   const [inputValue, setInputValue] = useState<string | null>('');
   const [isLoading, setIsLoading] = useState(false);
   const [selected, setSelected] =
@@ -98,7 +105,7 @@ export default function MoreRecommendations(props: Props) {
           // @ts-ignore */}
       <MultiSelect
         className="!w-full"
-        labelText="Select related skills"
+        labelText={labelText || 'Select related skills'}
         optionalText="Optional"
         visualPlaceholder="Type to search"
         itemAdditionHelpText=""

--- a/packages/vf-shared/src/components/pages/profile/language-skills-select/languages-edit.tsx
+++ b/packages/vf-shared/src/components/pages/profile/language-skills-select/languages-edit.tsx
@@ -25,13 +25,15 @@ export default function LanguagesEdit(props: Props) {
   const { userLanguages, escoLanguages, languageSkillLevels, onSave, onClose } =
     props;
 
-  const { handleSubmit, control } = useForm<FormProps>({
+  const { handleSubmit, control, watch } = useForm<FormProps>({
     defaultValues: userLanguages
       ? { languages: userLanguages }
       : {
           languages: [DEFAULT_VALUE],
         },
   });
+
+  const languages = watch('languages');
 
   const { fields, append, remove } = useFieldArray<FormProps>({
     control,
@@ -55,44 +57,63 @@ export default function LanguagesEdit(props: Props) {
       <div className="flex flex-col gap-3">
         {!fields.length && <Text>No language skills selected.</Text>}
 
-        {fields.map((field, index) => (
-          <div
-            key={field.id}
-            className="grid grid-cols-1 sm:grid-cols-3 gap-3 items-end border-b border-gray-300 pb-4"
-          >
-            <FormSingleSelect
-              name={`languages.${index}.languageCode`}
-              control={control}
-              rules={{ required: true }}
-              labelText="Select language"
-              items={escoLanguages.map(l => ({
-                labelText: l.name,
-                uniqueItemId: l.twoLetterISOLanguageName,
-              }))}
-            />
-            <FormSingleSelect
-              name={`languages.${index}.skillLevel`}
-              control={control}
-              rules={{ required: true }}
-              labelText="Skill level"
-              items={languageSkillLevels
-                .filter(l => l.codeValue.length === 2)
-                .map(l => ({
-                  labelText: l.prefLabel.en,
-                  uniqueItemId: l.codeValue,
+        {fields.map((field, index) => {
+          const languageCode = languages[index].languageCode;
+          const languageLabel = languageCode
+            ? escoLanguages.find(
+                l => l.twoLetterISOLanguageName === languageCode
+              )?.name
+            : undefined;
+
+          return (
+            <div
+              key={field.id}
+              className="grid grid-cols-1 sm:grid-cols-3 gap-3 items-end border-b border-gray-300 pb-4"
+            >
+              <FormSingleSelect
+                name={`languages.${index}.languageCode`}
+                control={control}
+                rules={{ required: true }}
+                labelText="Select language"
+                items={escoLanguages.map(l => ({
+                  labelText: l.name,
+                  uniqueItemId: l.twoLetterISOLanguageName,
                 }))}
-            />
-            <div>
-              <Button
-                variant="link"
-                iconRight={<IconRemove />}
-                onClick={() => remove(index)}
-              >
-                Remove
-              </Button>
+              />
+              <FormSingleSelect
+                name={`languages.${index}.skillLevel`}
+                control={control}
+                rules={{ required: true }}
+                labelText={
+                  <>
+                    Skill level{' '}
+                    {languageLabel && (
+                      <span className="sr-only">for {languageLabel}.</span>
+                    )}
+                  </>
+                }
+                items={languageSkillLevels
+                  .filter(l => l.codeValue.length === 2)
+                  .map(l => ({
+                    labelText: l.prefLabel.en,
+                    uniqueItemId: l.codeValue,
+                  }))}
+              />
+              <div>
+                <Button
+                  variant="link"
+                  iconRight={<IconRemove />}
+                  onClick={() => remove(index)}
+                >
+                  Remove{' '}
+                  <span className="sr-only">
+                    {languageLabel || 'language skill'}
+                  </span>
+                </Button>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
       <div className="mt-4">
         <Button
@@ -100,7 +121,7 @@ export default function LanguagesEdit(props: Props) {
           iconRight={<IconPlus />}
           onClick={() => append(DEFAULT_VALUE)}
         >
-          Add new
+          Add new <span className="sr-only">language skill</span>
         </Button>
       </div>
       <div className="flex flex-row gap-3 mt-8">

--- a/packages/vf-shared/src/components/pages/profile/occupations-select/occupations-additional-info.tsx
+++ b/packages/vf-shared/src/components/pages/profile/occupations-select/occupations-additional-info.tsx
@@ -71,7 +71,14 @@ export default function OccupationsAdditionalInfo(props: Props) {
                 name={`occupations.${index}.employer`}
                 control={control}
                 rules={{ required: 'Employer is required. ' }}
-                labelText="Employer"
+                labelText={
+                  <>
+                    Employer{' '}
+                    <span className="sr-only">
+                      for {field.label} occupation
+                    </span>
+                  </>
+                }
               />
               <FormInput
                 type="number"
@@ -81,7 +88,14 @@ export default function OccupationsAdditionalInfo(props: Props) {
                   required: 'Work experience is required.',
                   valueAsNumber: true,
                 }}
-                labelText="Work experience (years)"
+                labelText={
+                  <>
+                    Work experience (years){' '}
+                    <span className="sr-only">
+                      for {field.label} occupation
+                    </span>
+                  </>
+                }
                 min={0}
                 step={0.5}
               />
@@ -92,7 +106,7 @@ export default function OccupationsAdditionalInfo(props: Props) {
                 iconRight={<IconRemove />}
                 onClick={() => remove(index)}
               >
-                Remove
+                Remove <span className="sr-only">{field.label}</span>
               </Button>
             </div>
           </div>
@@ -101,7 +115,7 @@ export default function OccupationsAdditionalInfo(props: Props) {
 
       <div className="flex flecx-row items-start gap-3 mt-4">
         <Button variant="secondary" icon={<IconArrowLeft />} onClick={goBack}>
-          Back
+          Back <span className="sr-only">to occupations search and select</span>
         </Button>
         <Button disabled={!selected.length} type="submit">
           Save

--- a/packages/vf-shared/src/components/pages/profile/occupations-select/occupations-edit.tsx
+++ b/packages/vf-shared/src/components/pages/profile/occupations-select/occupations-edit.tsx
@@ -89,7 +89,12 @@ export default function OccupationsEdit(props: Props) {
             iconRight={<IconArrowRight />}
             onClick={() => setPhase('additional-info')}
           >
-            ({selected?.length || 0}) Selected
+            ({selected?.length || 0}){' '}
+            <span className="sr-only">occupations</span> Selected{' '}
+            <span className="sr-only">
+              . Click to next phase to add additional information and to save
+              selected occupations.
+            </span>
           </Button>
         </div>
       </div>

--- a/packages/vf-shared/src/components/pages/profile/other-skills-select/other-skills-additional-info.tsx
+++ b/packages/vf-shared/src/components/pages/profile/other-skills-select/other-skills-additional-info.tsx
@@ -56,7 +56,14 @@ export default function OtherSkillsAdditionalInfo(props: Props) {
                 name={`otherSkills.${index}.skillLevel`}
                 control={control}
                 rules={{ required: true }}
-                labelText="Skill level"
+                labelText={
+                  <>
+                    Skill level{' '}
+                    <span className="sr-only">
+                      for {field.label || field.escoIdentifier}
+                    </span>
+                  </>
+                }
                 items={Object.keys(SkillLevel).map(type => ({
                   labelText:
                     SKILL_LEVEL_LABELS[type as keyof typeof SKILL_LEVEL_LABELS],
@@ -69,7 +76,10 @@ export default function OtherSkillsAdditionalInfo(props: Props) {
                   iconRight={<IconRemove />}
                   onClick={() => remove(index)}
                 >
-                  Remove
+                  Remove{' '}
+                  <span className="sr-only">
+                    {field.label || field.escoIdentifier}
+                  </span>
                 </Button>
               </div>
             </div>
@@ -79,7 +89,7 @@ export default function OtherSkillsAdditionalInfo(props: Props) {
 
       <div className="flex flecx-row items-start gap-3 mt-4">
         <Button variant="secondary" icon={<IconArrowLeft />} onClick={onBack}>
-          Back
+          Back <span className="sr-only">to skills search and select</span>
         </Button>
         <Button disabled={!selected.length} type="submit">
           Save

--- a/packages/vf-shared/src/components/pages/profile/other-skills-select/other-skills-edit.tsx
+++ b/packages/vf-shared/src/components/pages/profile/other-skills-select/other-skills-edit.tsx
@@ -76,7 +76,12 @@ export default function OtherSkillsEdit(props: Props) {
             iconRight={<IconArrowRight />}
             onClick={() => setPhase('additional-info')}
           >
-            ({selected?.length || 0}) Selected
+            ({selected?.length || 0}) <span className="sr-only">skills</span>{' '}
+            Selected
+            <span className="sr-only">
+              . Click to next phase to add additional information and to save
+              selected skills.
+            </span>
           </Button>
         </div>
       </div>

--- a/packages/vf-shared/src/components/ui/custom-link.tsx
+++ b/packages/vf-shared/src/components/ui/custom-link.tsx
@@ -22,7 +22,10 @@ type CustomLinkProps = Omit<SuomiFiLinkProps, 'href'> &
   StyledLinkProps;
 
 const CustomLink = forwardRef<HTMLAnchorElement, CustomLinkProps>(
-  ({ href, replace, scroll, shallow, locale, $bold, $base, children }, ref) => {
+  (
+    { href, replace, scroll, shallow, locale, $bold, $base, children, onClick },
+    ref
+  ) => {
     return (
       <NextLink
         href={href}
@@ -33,7 +36,13 @@ const CustomLink = forwardRef<HTMLAnchorElement, CustomLinkProps>(
         passHref
         legacyBehavior
       >
-        <StyledLink href="" ref={ref} $bold={$bold} $base={$base}>
+        <StyledLink
+          href=""
+          ref={ref}
+          $bold={$bold}
+          $base={$base}
+          onClick={onClick}
+        >
           {children}
         </StyledLink>
       </NextLink>

--- a/packages/vf-shared/src/components/ui/modal.tsx
+++ b/packages/vf-shared/src/components/ui/modal.tsx
@@ -46,7 +46,7 @@ export default function Modal(props: Props) {
       variant={width > 640 ? 'default' : 'smallScreen'}
       onEscKeyDown={() => closeOnEsc && closeModal()}
     >
-      <FocusLockUI sideCar={FocusLockSidecar}>
+      <FocusLockUI sideCar={FocusLockSidecar} className="overflow-auto">
         <ModalContent>
           <ModalTitle>{title}</ModalTitle>
           {content}

--- a/packages/vf-shared/src/components/ui/modal.tsx
+++ b/packages/vf-shared/src/components/ui/modal.tsx
@@ -1,14 +1,21 @@
 import dynamic from 'next/dynamic';
 import { ReactNode } from 'react';
+import FocusLockUI from 'react-focus-lock/UI';
 import {
   ModalContent,
   ModalTitle,
   Modal as SuomiFiModal,
 } from 'suomifi-ui-components';
+import { sidecar } from 'use-sidecar';
 import useDimensions from '@/lib/hooks/use-dimensions';
 
 const ModalFooter = dynamic(() =>
   import('suomifi-ui-components').then(mod => mod.ModalFooter)
+);
+
+// https://github.com/theKashey/react-focus-lock#separated-usage
+const FocusLockSidecar = sidecar(
+  () => import(/* webpackPrefetch: true */ 'react-focus-lock/sidecar')
 );
 
 interface Props {
@@ -39,11 +46,13 @@ export default function Modal(props: Props) {
       variant={width > 640 ? 'default' : 'smallScreen'}
       onEscKeyDown={() => closeOnEsc && closeModal()}
     >
-      <ModalContent>
-        <ModalTitle>{title}</ModalTitle>
-        {content}
-      </ModalContent>
-      {footerContent && <ModalFooter>{footerContent}</ModalFooter>}
+      <FocusLockUI sideCar={FocusLockSidecar}>
+        <ModalContent>
+          <ModalTitle>{title}</ModalTitle>
+          {content}
+        </ModalContent>
+        {footerContent && <ModalFooter>{footerContent}</ModalFooter>}
+      </FocusLockUI>
     </SuomiFiModal>
   );
 }


### PR DESCRIPTION
Liittyen tikettiin: https://virtualfindev.atlassian.net/jira/software/projects/VFD/boards/3?selectedIssue=VFD-255

- Muokattu / vaihdettu DOM-elementtejä siellä täällä, jotta sovelluksessa navigointi onnistuu paremmin tabulaattorilla / on semanttisesti validimpi
- Modaaliin lisätty focus lock / trap, jotta focusta ei menetetä, jos modaalin sisältö vaihtuu ohjelmallisesti (esim. occupations valinta, painellaan (n) selected -nappia niin sisältö vaihtuu editointiin)
- Profile formit: muokkauksia etenkin modaaleissa suoritettaviin toimintoihin - dynaamiset labelit (screen readereille), jotta konteksti on tietoja täyttäessä paremmin selvillä. Modaaleissa navigointinappeihin (back, selected ->, yms) lisätty myös sr-only tekstit helpottamaan hahmottamista
- vf-features puolelle (eli PRH osuus) ei muutoksia - jos niitä joskus tarvitsee niin saman tyyppisiä parannuksia voi tehdä myös sille puolelle.

Applen VoiceOveria käytetty screen readerina.

a11y improvments v2, koska tästä oli v1 jo olemassa joka tosin tuli mergeiltyä ilman katselmointia. Tämän voipi sitten vilkuilla ja testailla vaikka tabulaattorin hakkaamisella ja ehkä kokeilla jollain muulla screen readerilla jos huvituttaa.