### PR TITLE
Separate docker compose file for mvp-only dev-env

### DIFF
--- a/docker-compose.mvp-dev.yml
+++ b/docker-compose.mvp-dev.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+
+services:
+  virtual-finland:
+    image: node:18-alpine
+    user: node
+    command: sh -c "npm install && npm run dev:mvp"
+    working_dir: /app
+    volumes:
+      - .:/app
+      - $HOME/.aws:/home/node/.aws:ro
+    stdin_open: true
+    tty: true
+    ports:
+      - 3006:3001
+    networks:
+      - vfd-network
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    environment:
+      - NEXT_PUBLIC_USERS_API_BASE_URL=${NEXT_PUBLIC_USERS_API_BASE_URL:-http://host.docker.internal:5001}
+      - BACKEND_SECRET_SIGN_KEY=${BACKEND_SECRET_SIGN_KEY:-secret}
+      - AWS_PROFILE=${AWS_PROFILE:-default}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.virtual-finland-mvp.rule=Host(`virtual-finland.localhost`)
+      - traefik.http.routers.virtual-finland-mvp.entrypoints=web
+      - traefik.http.routers.virtual-finland-mvp.service=virtual-finland-mvp-service
+      - traefik.http.services.virtual-finland-mvp-service.loadbalancer.server.port=3001
+      - traefik.http.routers.virtual-finland-features.rule=Host(`features.virtual-finland.localhost`)
+      - traefik.http.routers.virtual-finland-features.entrypoints=web
+      - traefik.http.routers.virtual-finland-features.service=virtual-finland-features-service
+      - traefik.http.services.virtual-finland-features-service.loadbalancer.server.port=3000
+
+networks:
+  vfd-network:
+    external: true
+    driver: bridge

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:watch": "turbo run test:watch",
     "test:ci": "turbo run test:ci",
     "dev": "turbo run dev",
+    "dev:mvp": "turbo run dev --filter=vf-mvp",
+    "dev:features": "turbo run dev --filter=vf-features",
     "lint": "turbo run lint",
     "clean": "turbo run clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",


### PR DESCRIPTION
- add a composer file that starts the vf-mvp app development environment only
- new npm commands: `dev:mvp` and `dev:features`

Relates to vfd-tools [PR](https://github.com/Virtual-Finland-Development/vfd-tools/pull/8)