### PR TITLE
Enchacements to token expiration handling

### DIFF
--- a/apps/af-features/src/pages/profile/personal-profile.page.tsx
+++ b/apps/af-features/src/pages/profile/personal-profile.page.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { IconUserProfile } from 'suomifi-ui-components';
 import { Text } from 'suomifi-ui-components';
 import { usePersonBasicInfo } from '@shared/lib/hooks/profile';
+import { useAuth } from '@shared/context/auth-context';
 import AuthSentry from '@shared/components/auth-sentry';
 import Page from '@shared/components/layout/page';
 import PersonalProfileForm from '@shared/components/pages/profile/personal-profile-form';
@@ -9,7 +10,9 @@ import CustomHeading from '@shared/components/ui/custom-heading';
 import Loading from '@shared/components/ui/loading';
 
 export default function PersonalProfilePage() {
-  const { data: personBasicInformation, isLoading } = usePersonBasicInfo();
+  const { isAuthenticated } = useAuth();
+  const { data: personBasicInformation, isLoading } =
+    usePersonBasicInfo(isAuthenticated);
   const router = useRouter();
 
   return (

--- a/apps/af-features/src/pages/profile/working-profile.page.tsx
+++ b/apps/af-features/src/pages/profile/working-profile.page.tsx
@@ -1,6 +1,7 @@
 import { IconUserBadge } from 'suomifi-ui-components';
 import { Text } from 'suomifi-ui-components';
 import { useJobApplicantProfile } from '@shared/lib/hooks/profile';
+import { useAuth } from '@shared/context/auth-context';
 import AuthSentry from '@shared/components/auth-sentry';
 import Page from '@shared/components/layout/page';
 import WorkingProfileForm from '@shared/components/pages/profile/working-profile-form';
@@ -8,7 +9,9 @@ import CustomHeading from '@shared/components/ui/custom-heading';
 import Loading from '@shared/components/ui/loading';
 
 export default function WorkingProfilePage() {
-  const { data: jobApplicationProfile, isLoading } = useJobApplicantProfile();
+  const { isAuthenticated } = useAuth();
+  const { data: jobApplicationProfile, isLoading } =
+    useJobApplicantProfile(isAuthenticated);
 
   return (
     <AuthSentry redirectPath="/profile">

--- a/apps/af-mvp/src/pages/api/auth/login-response.route.ts
+++ b/apps/af-mvp/src/pages/api/auth/login-response.route.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { createApiAuthPackage } from '@mvp/lib/backend/ApiAuthPackage';
 import { resolveIdTokenExpiresAt } from '@mvp/lib/backend/api-utils';
 import { loggedOutAuthMiddleware } from '@mvp/lib/backend/middleware/auth';
@@ -6,7 +7,6 @@ import {
   retrieveUserInfoWithAccessToken,
 } from '@mvp/lib/backend/services/sinuna/sinuna-requests';
 import cookie from 'cookie';
-import type { NextApiRequest, NextApiResponse } from 'next';
 import { object, parse, string } from 'valibot';
 
 const LoginResponseSchema = object({

--- a/apps/af-mvp/src/pages/profile/personal-profile.page.tsx
+++ b/apps/af-mvp/src/pages/profile/personal-profile.page.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { IconUserProfile } from 'suomifi-ui-components';
 import { Text } from 'suomifi-ui-components';
 import { usePersonBasicInfo } from '@shared/lib/hooks/profile';
+import { useAuth } from '@shared/context/auth-context';
 import AuthSentry from '@shared/components/auth-sentry';
 import Page from '@shared/components/layout/page';
 import PersonalProfileForm from '@shared/components/pages/profile/personal-profile-form';
@@ -9,7 +10,9 @@ import CustomHeading from '@shared/components/ui/custom-heading';
 import Loading from '@shared/components/ui/loading';
 
 export default function PersonalProfilePage() {
-  const { data: personBasicInformation, isLoading } = usePersonBasicInfo();
+  const { isAuthenticated } = useAuth();
+  const { data: personBasicInformation, isLoading } =
+    usePersonBasicInfo(isAuthenticated);
   const router = useRouter();
 
   return (

--- a/apps/af-mvp/src/pages/profile/working-profile.page.tsx
+++ b/apps/af-mvp/src/pages/profile/working-profile.page.tsx
@@ -1,6 +1,7 @@
 import { IconUserBadge } from 'suomifi-ui-components';
 import { Text } from 'suomifi-ui-components';
 import { useJobApplicantProfile } from '@shared/lib/hooks/profile';
+import { useAuth } from '@shared/context/auth-context';
 import AuthSentry from '@shared/components/auth-sentry';
 import Page from '@shared/components/layout/page';
 import WorkingProfileForm from '@shared/components/pages/profile/working-profile-form';
@@ -8,7 +9,9 @@ import CustomHeading from '@shared/components/ui/custom-heading';
 import Loading from '@shared/components/ui/loading';
 
 export default function WorkingProfilePage() {
-  const { data: jobApplicationProfile, isLoading } = useJobApplicantProfile();
+  const { isAuthenticated } = useAuth();
+  const { data: jobApplicationProfile, isLoading } =
+    useJobApplicantProfile(isAuthenticated);
 
   return (
     <AuthSentry redirectPath="/profile">

--- a/packages/af-shared/src/context/modal-context.tsx
+++ b/packages/af-shared/src/context/modal-context.tsx
@@ -4,8 +4,10 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useState,
 } from 'react';
+import { REQUEST_NOT_AUTHORIZED } from '@/lib/constants';
 
 const Modal = dynamic(() => import('@/components/ui/modal'));
 
@@ -42,6 +44,20 @@ function ModalProvider({ children }: ModalProviderProps) {
 
     setModal(null);
   }, [modal]);
+
+  // Make sure any opened modal is closed when user is presented with alert window about expired token
+  useEffect(() => {
+    const onWindowMessageEvent = (event: MessageEvent) => {
+      if (event.data === REQUEST_NOT_AUTHORIZED) {
+        closeModal();
+      }
+    };
+    // make sure Next.js is running on client-side (window is defined), before attempting to add window listeners
+    if (typeof window !== 'undefined') {
+      window.addEventListener('message', onWindowMessageEvent);
+      return () => window.removeEventListener('message', onWindowMessageEvent);
+    }
+  }, [closeModal]);
 
   return (
     <ModalContext.Provider

--- a/packages/af-shared/src/lib/hooks/profile.ts
+++ b/packages/af-shared/src/lib/hooks/profile.ts
@@ -14,11 +14,11 @@ const QUERY_OPTIONS = {
 /**
  * Get person basic information.
  */
-function usePersonBasicInfo() {
+function usePersonBasicInfo(enabled: boolean = true) {
   const query = useQuery(
     BASIC_INFO_QUERY_KEYS,
     async () => await api.profile.getPersonBasicInfo(),
-    QUERY_OPTIONS
+    { ...QUERY_OPTIONS, enabled }
   );
 
   useErrorToast({
@@ -35,11 +35,11 @@ function usePersonBasicInfo() {
 /**
  * Get person job applicant profile.
  */
-function useJobApplicantProfile() {
+function useJobApplicantProfile(enabled: boolean = true) {
   const query = useQuery(
     JOB_APPLICATION_QUERY_KEYS,
     async () => await api.profile.getJobApplicantProfile(),
-    QUERY_OPTIONS
+    { ...QUERY_OPTIONS, enabled }
   );
 
   useErrorToast({


### PR DESCRIPTION
- Estetään duplikaattialerttien näyttäminen, jos token on vanhentunut:
   - Aikaisemmin, jos haettiin esim. peräkanaa molemmat profiilidatatuotteet, molemmista tuli alertti.
- Passataan profile-hookeille boolean arvo kertomaan, voidaanko profiledatoja hakea (onko käyttäjä autentikoitunut):
   - Estetään rajatapaus -> esim. profile/working-profile sivulla ollessa page refresh, ja jos token on kuollut, niin ei turhaan tehdä requestia (AuthSentryn uudelleenohjaus profile sivulle tapahtuu vasta jälkijunassa).
 - Modaalit: aukinainen modaali suljetaan, jos havaitaan token expiration alertin tapahtuneen.