### PR TITLE
Redirect cancelled login-flow back to the frontend

### DIFF
--- a/apps/af-features/src/pages/auth.page.tsx
+++ b/apps/af-features/src/pages/auth.page.tsx
@@ -76,13 +76,15 @@ export default function AuthPage() {
 
   if (authError) {
     return (
-      <div className="min-w-xl max-w-xl">
-        <Alert status="error" labelText="Error">
-          <div className="flex flex-col gap-3">
-            <Text>{authError}</Text>
-            <CustomLink href="/">Go to home page</CustomLink>
-          </div>
-        </Alert>
+      <div className="container flex justify-center p-4">
+        <div className="w-[600px]">
+          <Alert status="error" labelText="Error">
+            <div className="flex flex-col gap-3">
+              <Text>{authError}</Text>
+              <CustomLink href="/">Go to home page</CustomLink>
+            </div>
+          </Alert>
+        </div>
       </div>
     );
   }

--- a/apps/af-mvp/src/pages/api/auth/login-response.route.ts
+++ b/apps/af-mvp/src/pages/api/auth/login-response.route.ts
@@ -87,7 +87,7 @@ export default loggedOutAuthMiddleware(async function handler(
     //
     // Redirect to the frontend with the error
     //
-    return res.redirect(303, `${returnBackUri}?error=${badEvent.data.error}?error_description=${badEvent.data.error_description}`);
+    return res.redirect(303, `${returnBackUri}?error=${badEvent.data.error}&error_description=${badEvent.data.error_description}`);
   }
 
   throw new Error('Invalid login response.');

--- a/apps/af-mvp/src/pages/auth.page.tsx
+++ b/apps/af-mvp/src/pages/auth.page.tsx
@@ -37,6 +37,8 @@ export default function AuthPage({
   const [authError, setAuthError] = useState<string | null>(null);
   const [isLoading, setLoading] = useState(false);
   const router = useRouter();
+  const { error } = router.query;
+  const userCancelled = error && error === 'cancelled';
 
   const routerActions = useCallback(async () => {
     setLoading(true);
@@ -50,8 +52,8 @@ export default function AuthPage({
 
     // Login was a no-show
     setLoading(false);
-    setAuthError('Authentication failed.');
-  }, [csrfToken]);
+    setAuthError(userCancelled ? 'Login cancelled.' : 'Authentication failed.');
+  }, [csrfToken, userCancelled]);
 
   useEffect(() => {
     if (router.isReady) {
@@ -63,15 +65,20 @@ export default function AuthPage({
     return <Loading />;
   }
 
+  const status = userCancelled ? 'warning' : 'error';
+  const labelText = userCancelled ? 'Cancelled' : 'Error';
+
   if (authError) {
     return (
-      <div className="min-w-xl max-w-xl">
-        <Alert status="error" labelText="Error">
-          <div className="flex flex-col gap-3">
-            <Text>{authError}</Text>
-            <CustomLink href="/">Go to home page</CustomLink>
-          </div>
-        </Alert>
+      <div className="container flex justify-center p-4">
+        <div className="w-[600px]">
+          <Alert status={status} labelText={labelText}>
+            <div className="flex flex-col gap-3">
+              <Text>{authError}</Text>
+              <CustomLink href="/">Go to home page</CustomLink>
+            </div>
+          </Alert>
+        </div>
       </div>
     );
   }

--- a/apps/af-mvp/src/pages/auth.page.tsx
+++ b/apps/af-mvp/src/pages/auth.page.tsx
@@ -17,7 +17,7 @@ export const getServerSideProps: GetServerSideProps<{
   let csrfToken = null;
 
   if (req.cookies.csrfToken) {
-    // Pop the auth token from the cookie
+    // Pop (retrieve and clear) the auth token from the cookie
     csrfToken = req.cookies.csrfToken;
     res.setHeader(
       'Set-Cookie',


### PR DESCRIPTION
Jos käyttäjä peruuttaa kirjautumisen tai siinä käy joku muu virhe, palautetaan käyttäjä takaisin fronttisovellukseen. Aikaisemmin Sinunalta takaisin paluu virhetilanteen kanssa pysäytti käyttäjän api-sivulle josta ei klikkaillemalla pystynyt etenemään.
  
Flowta voi testata esim. näin:

-  Sivustolla https://frontend.sunbackend.qa.sinuna.fi/ kirjautuneena navigoi ja klikkaa: 
    - Manage access -> Manage sharing your data -> VFDevelopmentApp -> Stop sharing data
- Access Finland-sivustolla (local tai dev-live) kirjaudu sisään Sinunalla 
    - kirjautuminen pitäisi pysähtyä sivulle jonka otsikko: "Allow sharing of your data"
- Tietojen käyttöoikeutusformissa klikkaa "Cancel" 

--> käyttäjän pitäisi palautua takaisin AF-fronttiin.

Huom. virhetilanteessa fronttiin ohjatessa `/auth`-sivulle annetaan query-parametreinä tekstiviestit `error` ja `error_description` jotka tulevat suoraan Sinunalta, loginin peruutustilanteessa siellä lukee jotain `error=cancelled` ja `error_description=user clicked cancel`.