### PR TITLE
fix: disable caching of the terms of service retrieval request

### DIFF
--- a/apps/af-mvp/src/lib/backend/services/users-api/users-api-router.ts
+++ b/apps/af-mvp/src/lib/backend/services/users-api/users-api-router.ts
@@ -26,6 +26,10 @@ const UsersApiRouter = {
             usersApiRequestHeaders
           );
         case 'GET /api/users-api/terms-of-service':
+          // Prevent cloudfront caching of the GET-response
+          // @see: https://nextjs.org/docs/pages/api-reference/next-config-js/headers#cache-control
+          res.setHeader('Cache-Control', 'no-store');
+
           return await UsersApiRouter.retrieveTermsOfService(
             req,
             res,

--- a/infra/af-mvp/resources/cloudfront.ts
+++ b/infra/af-mvp/resources/cloudfront.ts
@@ -67,15 +67,7 @@ export function createContentDeliveryNetwork(
       defaultCacheBehavior: {
         targetOriginId: loadBalancerSetup.appLoadBalancer.arn,
         viewerProtocolPolicy: 'redirect-to-https',
-        allowedMethods: [
-          'HEAD',
-          'DELETE',
-          'POST',
-          'GET',
-          'OPTIONS',
-          'PUT',
-          'PATCH',
-        ],
+        allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
         cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
         defaultTtl: 600,
         maxTtl: 600,
@@ -87,6 +79,32 @@ export function createContentDeliveryNetwork(
           },
         },
       },
+      orderedCacheBehaviors: [
+        {
+          pathPattern: '/api/*',
+          targetOriginId: loadBalancerSetup.appLoadBalancer.arn,
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: [
+            'HEAD',
+            'DELETE',
+            'POST',
+            'GET',
+            'OPTIONS',
+            'PUT',
+            'PATCH',
+          ],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          defaultTtl: 0,
+          maxTtl: 0,
+          minTtl: 0,
+          forwardedValues: {
+            queryString: true,
+            cookies: {
+              forward: 'all',
+            },
+          },
+        },
+      ],
       restrictions: {
         geoRestriction: {
           restrictionType: 'none',


### PR DESCRIPTION
- fixes the issue where the tos-agreement saving seems not to work
  - disables caching of the GET-request by:
    - adding a no-store cache-control header to the response 
    - ~~setting the cloudfront caching to respect the origin headers~~ (maybe later with some advanced pulumi triks)
    - configuring cloudfront to skip caching for all requests to /api/*