### PR TITLE
Add health-check API route handler.

### DIFF
--- a/apps/af-mvp/src/pages/api/health-check.route.ts
+++ b/apps/af-mvp/src/pages/api/health-check.route.ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+async function handler(_: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ message: 'OK' });
+}
+export default handler;

--- a/docker-compose.mvp-dev.yml
+++ b/docker-compose.mvp-dev.yml
@@ -11,6 +11,15 @@ services:
       - $HOME/.aws:/home/node/.aws:ro
     stdin_open: true
     tty: true
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'wget --no-verbose --tries=1 --spider http://localhost:3001/api/health-check || exit 1',
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
     ports:
       - 3006:3001
     networks:

--- a/docker-compose.mvp.yml
+++ b/docker-compose.mvp.yml
@@ -6,7 +6,15 @@ services:
     build:
       context: .
       dockerfile: ./apps/af-mvp/Dockerfile
-    restart: always
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'wget --no-verbose --tries=1 --spider http://$(hostname):3000/api/health-check || exit 1',
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
     environment:
       - AWS_PROFILE=${AWS_PROFILE:-default}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,15 @@ services:
       - $HOME/.aws:/home/node/.aws:ro
     stdin_open: true
     tty: true
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'wget --no-verbose --tries=1 --spider http://localhost:3001/api/health-check || exit 1',
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
     ports:
       - 3005:3000
       - 3006:3001

--- a/infra/af-mvp/resources/fargate.ts
+++ b/infra/af-mvp/resources/fargate.ts
@@ -117,6 +117,16 @@ export function createFargateService(
               'awslogs-stream-prefix': 'service',
             },
           },
+          healthCheck: {
+            command: [
+              'CMD-SHELL',
+              'wget --no-verbose --tries=1 --spider http://localhost:3001/api/health-check || exit 1',
+            ],
+            interval: 30,
+            retries: 3,
+            startPeriod: 60,
+            timeout: 5,
+          },
         },
       },
       taskRole: {

--- a/infra/af-mvp/resources/fargate.ts
+++ b/infra/af-mvp/resources/fargate.ts
@@ -120,11 +120,11 @@ export function createFargateService(
           healthCheck: {
             command: [
               'CMD-SHELL',
-              'wget --no-verbose --tries=1 --spider http://localhost:3001/api/health-check || exit 1',
+              'wget --no-verbose --tries=1 --spider http://$(hostname):3000/api/health-check || exit 1',
             ],
             interval: 30,
             retries: 3,
-            startPeriod: 60,
+            startPeriod: 10,
             timeout: 5,
           },
         },


### PR DESCRIPTION
- add a simple json-response for the use of a fargate-service health check routine at route `/api/health-check`
- add health checks to the fargate and local docker-compose files