### PR TITLE
Send traceId to the codesets

### DIFF
--- a/apps/af-mvp/package.json
+++ b/apps/af-mvp/package.json
@@ -19,7 +19,6 @@
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "uuid": "^9.0.1",
     "valibot": "^0.8.0"
   },
   "devDependencies": {

--- a/apps/af-mvp/src/lib/backend/middleware/requestTracing.ts
+++ b/apps/af-mvp/src/lib/backend/middleware/requestTracing.ts
@@ -7,7 +7,7 @@ import { Logger } from '../Logger';
  */
 export function requestTracingMiddleware(handler: NextApiHandlerWithLogger) {
   return async (req: NextApiRequest, res: NextApiResponse, logger: Logger) => {
-    const traceId = req.headers['X-Request-Trace-Id'] || uuidv4();
+    const traceId = (req.headers['X-Request-Trace-Id'] || uuidv4()) as string;
     req.headers['X-Request-Trace-Id'] = traceId;
     logger.setTraceId(traceId); // Pass traceId to logger so it'll show up in logs for the current request
     return await handler(req, res, logger);

--- a/apps/af-mvp/src/lib/backend/middleware/requestTracing.ts
+++ b/apps/af-mvp/src/lib/backend/middleware/requestTracing.ts
@@ -7,7 +7,7 @@ import { Logger } from '../Logger';
  */
 export function requestTracingMiddleware(handler: NextApiHandlerWithLogger) {
   return async (req: NextApiRequest, res: NextApiResponse, logger: Logger) => {
-    const traceId = uuidv4();
+    const traceId = req.headers['X-Request-Trace-Id'] || uuidv4();
     req.headers['X-Request-Trace-Id'] = traceId;
     logger.setTraceId(traceId); // Pass traceId to logger so it'll show up in logs for the current request
     return await handler(req, res, logger);

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.get": "^4.4.2",
         "lodash.groupby": "^4.6.0",
-        "next": "*",
+        "next": "latest",
         "next-image-export-optimizer": "^1.8.0",
         "next-safe": "^3.4.1",
         "pdfjs-dist": "^3.5.141",
@@ -71,7 +71,7 @@
       "version": "1.0.0",
       "dependencies": {
         "af-shared": "*",
-        "next": "*",
+        "next": "latest",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -113,10 +113,9 @@
         "aws-jwt-verify": "^4.0.0",
         "dotenv": "^16.3.1",
         "jsonwebtoken": "^9.0.0",
-        "next": "*",
+        "next": "latest",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "uuid": "^9.0.1",
         "valibot": "^0.8.0"
       },
       "devDependencies": {
@@ -148,18 +147,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "apps/af-mvp/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3734,6 +3721,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -7464,9 +7457,9 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphql": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -13250,9 +13243,9 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/sharp": {
-      "version": "0.32.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.5.tgz",
-      "integrity": "sha512-0dap3iysgDkNaPOaOL4X/0akdu0ma62GcdC2NBQ+93eqpePdDdr2/LM0sFdDSMmN7yS+odyZtPsb7tx/cYBKnQ==",
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
@@ -15307,8 +15300,12 @@
     },
     "packages/af-shared": {
       "version": "0.0.0",
+      "dependencies": {
+        "uuid": "^9.0.1"
+      },
       "devDependencies": {
         "@types/react": "^18.0.26",
+        "@types/uuid": "^9.0.7",
         "eslint": "^7.32.0",
         "eslint-config-custom": "*",
         "postcss": "^8.4.31",
@@ -15333,13 +15330,25 @@
         "node": ">=4.2.0"
       }
     },
+    "packages/af-shared/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "packages/eslint-config-custom": {
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "eslint-config-next": "*",
+        "eslint-config-next": "latest",
         "eslint-config-prettier": "^8.3.0",
-        "eslint-config-turbo": "*",
+        "eslint-config-turbo": "latest",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.32.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "rtf.js": "^3.0.9",
         "sharp": "^0.32.0",
         "styled-components": "^5.3.10",
-        "suomifi-ui-components": "^11.0.0"
+        "suomifi-ui-components": "^11.0.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@axe-core/react": "^4.7.2",
@@ -50,6 +51,7 @@
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/testing-library__jest-dom": "^5.14.7",
+        "@types/uuid": "^9.0.7",
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-transform-dynamic-import": "^2.1.0",
         "duplicate-package-checker-webpack-plugin": "^3.0.0",
@@ -326,6 +328,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -2778,6 +2788,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@smithy/middleware-serde": {
@@ -14698,9 +14716,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -15300,12 +15322,8 @@
     },
     "packages/af-shared": {
       "version": "0.0.0",
-      "dependencies": {
-        "uuid": "^9.0.1"
-      },
       "devDependencies": {
         "@types/react": "^18.0.26",
-        "@types/uuid": "^9.0.7",
         "eslint": "^7.32.0",
         "eslint-config-custom": "*",
         "postcss": "^8.4.31",
@@ -15328,18 +15346,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "packages/af-shared/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "packages/eslint-config-custom": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "rtf.js": "^3.0.9",
     "sharp": "^0.32.0",
     "styled-components": "^5.3.10",
-    "suomifi-ui-components": "^11.0.0"
+    "suomifi-ui-components": "^11.0.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@axe-core/react": "^4.7.2",
@@ -76,7 +77,8 @@
     "prettier": "^2.7.1",
     "prettier-plugin-tailwindcss": "^0.1.11",
     "serve": "^14.2.0",
-    "turbo": "^1.10.16"
+    "turbo": "^1.10.16",
+    "@types/uuid": "^9.0.7"
   },
   "packageManager": "npm@8.19.3",
   "workspaces": [

--- a/packages/af-shared/package.json
+++ b/packages/af-shared/package.json
@@ -2,9 +2,6 @@
   "name": "af-shared",
   "version": "0.0.0",
   "sideEffects": false,
-  "dependencies": {
-    "uuid": "^9.0.1"
-  },
   "peerDependencies": {
     "react": "^18.2.0"
   },
@@ -16,7 +13,6 @@
     "react": "^18.2.0",
     "tailwind-config": "*",
     "tsconfig": "*",
-    "typescript": "^4.9.4",
-    "@types/uuid": "^9.0.7"
+    "typescript": "^4.9.4"
   }
 }

--- a/packages/af-shared/package.json
+++ b/packages/af-shared/package.json
@@ -2,6 +2,9 @@
   "name": "af-shared",
   "version": "0.0.0",
   "sideEffects": false,
+  "dependencies": {
+    "uuid": "^9.0.1"
+  },
   "peerDependencies": {
     "react": "^18.2.0"
   },
@@ -13,6 +16,7 @@
     "react": "^18.2.0",
     "tailwind-config": "*",
     "tsconfig": "*",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "@types/uuid": "^9.0.7"
   }
 }


### PR DESCRIPTION
- in addition to sending the traceId to the direct users-api requests, send to the codesets too
- moves the traceId generation from the backend to the front
  - in the frontend there's a uri-group (similar to the existing pattern of using axios interceptors) where to the trace-header is generated when needed:
  - current rules for sending the trace-header apply to all internal API routes and the codesets-service routes, and only for the mvp-app cases
  - for dataspace-routes it currently means we generate the trace in vain as it's not forwarded to the dataspace by the backend, but it's a cheap op and as a structure makes sense not to do the opt-in configurations in multiple points of the request flow. Also, if we would have some frontend-kilkehärpäketutkain that's separate from the mpv-API, the trace would help there too.
- ~moved the uuid dependency to the af-shared package~
- updated npm package versions with npm audit suggestions
- relates to: https://github.com/Virtual-Finland-Development/codesets/pull/54