### PR TITLE
Fix all errors not alerted issue

### DIFF
--- a/infra/af-mvp/resources/fargate.ts
+++ b/infra/af-mvp/resources/fargate.ts
@@ -150,7 +150,7 @@ function createErrorMonitor(logGroup: aws.cloudwatch.LogGroup) {
     {
       logGroup: pulumi.interpolate`${logGroup.name}`,
       destinationArn: errorReportingFunctionArn,
-      filterPattern: 'ERROR',
+      filterPattern: '?"ERROR" ?"Error" ?"error"',
     }
   );
 }


### PR DESCRIPTION
Cloudwatchin logeja kuunnellessa käytettävä patterni on case-sensitive eli sananparsi "Error" ei mätsäydy patterniin "ERROR". Lisätty ohjeisiin muutama lisäehto että ei kävisi hassusti ja jäisi virheistä viestit lähtemättä (jos virhettä ei esim. logiteta request-loggerin kautta niin error-viestiin ei tule pakotettua "ERROR"-muotoa, mutta joku muoto sanasta "error"-kyllä pitäisi esiintyä). Pääosin virheet pitäisi kyllä mennä oikeassa muodossa, mutta tuosta vähän laajempi mätsäävyys: `?"ERROR" ?"Error" ?"error"`.
