### PR TITLE
Allow clearing the non-required person basic information fields

### DIFF
--- a/apps/af-mvp/src/lib/backend/services/dataspace/data-product-router.ts
+++ b/apps/af-mvp/src/lib/backend/services/dataspace/data-product-router.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import axios from 'axios';
+import { ValiError } from 'valibot';
 import { DataProductShemas, type DataProduct } from '@shared/types';
 import { decryptApiAuthPackage } from '../../ApiAuthPackage';
 import { Logger } from '../../Logger';
@@ -13,9 +14,9 @@ async function execute(
 ) {
   const apiAuthPackage = decryptApiAuthPackage(req.cookies.apiAuthPackage!);
   const endpoint = getDataProductEndpointInfo(dataProduct, dataSource);
-  const requestBody = parseDataProductRequestBody(dataProduct, req);
 
   try {
+    const requestBody = parseDataProductRequestBody(dataProduct, req);
     const response = await axios.post(endpoint.url.toString(), requestBody, {
       headers: {
         Authorization: `Bearer ${apiAuthPackage.idToken}`,
@@ -27,7 +28,8 @@ async function execute(
     res.status(response.status).json(response.data);
   } catch (error: any) {
     const errorContextPostfix = `${endpoint.dataProduct}:${endpoint.dataSource}:${endpoint.schemaVersion}`;
-    const statusCode = error.response?.status || 500;
+    const statusCode =
+      error.response?.status || (error instanceof ValiError ? 400 : 500);
     const responseData = error.response?.data?.type
       ? {
           message:

--- a/packages/af-shared/src/types/profile.ts
+++ b/packages/af-shared/src/types/profile.ts
@@ -6,7 +6,6 @@ import {
   nullable,
   number,
   object,
-  optional,
   string,
 } from 'valibot';
 
@@ -37,11 +36,11 @@ export type ProfileTosAgreementWrite = Output<
  * Person/BasicInformation
  */
 export const PersonBasicInformationSchema = object({
-  givenName: optional(string()),
-  lastName: optional(string()),
+  givenName: nullable(string()),
+  lastName: nullable(string()),
   email: string(),
-  phoneNumber: optional(string()),
-  residency: optional(string()),
+  phoneNumber: nullable(string()),
+  residency: nullable(string()),
 });
 export type PersonBasicInformation = Output<
   typeof PersonBasicInformationSchema


### PR DESCRIPTION
- change the person basic information optional values to nullable: allows the clearing of the residency value
  - other fields could be previously cleared as saved as empty string, but the residency clearing saved a null which caused err in the mvp-app input validation 
- wrap the data product input parsing to a try-catch to get a 400 error with info instead of just 500