### PR TITLE
Better dataspace error message parsing

### DIFF
--- a/apps/af-mvp/src/lib/backend/services/dataspace/data-product-router.ts
+++ b/apps/af-mvp/src/lib/backend/services/dataspace/data-product-router.ts
@@ -114,7 +114,7 @@ function parseDataspaceErrorMessage(messageObject?: any, statusCode?: number) {
 }
 
 /**
- * Regognizes if the error is a type of dataspace error response.
+ * Recognizes if the error is a type of dataspace error response.
  *
  * @param error
  * @returns


### PR DESCRIPTION
Dataspace returns a couple of different types of errors. The primary error payload is a simple `{type: string, message: string}`, but for validation errors (422) dataspace uses the pythonic structure `{detail: [{ msg: string, type: string, loc: string[] }]}`.

This PR updates the af-mvp app-error parsing regarding the 422-validation errors, so that the resulting alerts indicate the specific error right away.