### PR TITLE
Fix cognito cookie visibility when in login flow

### DIFF
--- a/apps/af-mvp/src/lib/backend/middleware/cognitoVerifyMiddleware.ts
+++ b/apps/af-mvp/src/lib/backend/middleware/cognitoVerifyMiddleware.ts
@@ -27,6 +27,7 @@ export function cognitoVerifyMiddleware(handler: NextApiHandlerWithLogger) {
       // Success
       return await handler(req, res, logger);
     } catch (error) {
+      logger.debug(error);
       // Clear the cognito session cookies
       res
         .setHeader('Set-Cookie', [

--- a/apps/af-mvp/src/pages/api/auth/cognito/callback.route.ts
+++ b/apps/af-mvp/src/pages/api/auth/cognito/callback.route.ts
@@ -87,7 +87,7 @@ async function handler(
           {
             path: '/api',
             httpOnly: true,
-            sameSite: 'strict',
+            sameSite: 'lax', // Must be lax for the redirect (from sinuna, back to the app) to work
             expires: new Date(expirity),
           }
         ),


### PR DESCRIPTION
When coming back from sinuna the cognito cookie was not visible causing a login flow err. This PR:
- fixes the visibility issue by setting the encrypted cognito cookie visibility from strict to lax
- adds a debug log to the cognito middleware error handler