### PR TITLE
Empty residency value null instead of empty string

### DIFF
--- a/packages/af-shared/src/components/pages/profile/personal-profile-form.tsx
+++ b/packages/af-shared/src/components/pages/profile/personal-profile-form.tsx
@@ -26,7 +26,7 @@ const DEFAULT_VALUES: PersonBasicInformation = {
   lastName: isExportedApp ? pickRandomName('lastName') : '',
   email: '',
   phoneNumber: isExportedApp ? '+1 231 231 2312' : '',
-  residency: '',
+  residency: null,
 };
 
 export default function PersonalProfileForm(props: Props) {

--- a/packages/af-shared/src/types/profile.ts
+++ b/packages/af-shared/src/types/profile.ts
@@ -2,6 +2,7 @@ import {
   Output,
   array,
   boolean,
+  length,
   nativeEnum,
   nullable,
   number,
@@ -40,7 +41,7 @@ export const PersonBasicInformationSchema = object({
   lastName: nullable(string()),
   email: string(),
   phoneNumber: nullable(string()),
-  residency: nullable(string()),
+  residency: nullable(string([length(3)])), // ISO 3166-1 alpha-3
 });
 export type PersonBasicInformation = Output<
   typeof PersonBasicInformationSchema


### PR DESCRIPTION
- fix empty residency value of basic information: null instead of empty string
- validate the input in backend too like that