### PR TITLE
More informative profile page loading experience

### DIFF
--- a/packages/af-shared/src/components/pages/profile/profile-details/profile-details.tsx
+++ b/packages/af-shared/src/components/pages/profile/profile-details/profile-details.tsx
@@ -1,7 +1,6 @@
-import { useRouter } from 'next/router';
-import { useMemo } from 'react';
-import { Button } from 'suomifi-ui-components';
-import type { JobApplicantProfile, PersonBasicInformation } from '@/types';
+import DangerButton from '@/components/ui/danger-button';
+import DetailsExpander from '@/components/ui/details-expander/details-expander';
+import { useModal } from '@/context/modal-context';
 import { PROFILE_DATA_LABELS } from '@/lib/constants';
 import {
   useCountries,
@@ -17,10 +16,10 @@ import {
   useRegions,
   useWorkPermits,
 } from '@/lib/hooks/codesets';
-import { useModal } from '@/context/modal-context';
-import DangerButton from '@/components/ui/danger-button';
-import DetailsExpander from '@/components/ui/details-expander/details-expander';
-import Loading from '@/components/ui/loading';
+import type { JobApplicantProfile, PersonBasicInformation } from '@/types';
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import { Button } from 'suomifi-ui-components';
 import ProfileDeleteConfirmation from './profile-delete-confirmation';
 import {
   mapReadableJobApplicationProfile,
@@ -67,8 +66,8 @@ export default function ProfileDetails(props: Props) {
   const { data: languageSkillLevels, isLoading: languageSkillLevelsLoading } =
     useLanguageSkillLevels(shouldFetchCodeSets);
 
-  const isLoading =
-    countriesLoading ||
+  const personBasicInfoCodeSetsLoading = countriesLoading;
+  const jobApplicationProfileCodeSetsLoading =
     occupationsLoading ||
     languagesLoading ||
     permitsLoading ||
@@ -83,7 +82,7 @@ export default function ProfileDetails(props: Props) {
 
   // map all personBasicInfo values to readable form
   const personBasicInfoMapped = useMemo(() => {
-    if (isLoading) return undefined;
+    if (personBasicInfoCodeSetsLoading) return undefined;
 
     if (personBasicInformation) {
       return mapReadablePersonBasicInfo(
@@ -91,11 +90,11 @@ export default function ProfileDetails(props: Props) {
         countries || []
       );
     }
-  }, [countries, isLoading, personBasicInformation]);
+  }, [countries, personBasicInfoCodeSetsLoading, personBasicInformation]);
 
   // map all jobApplicationProfile values to readable form
   const jobApplicationProfileMapped = useMemo(() => {
-    if (isLoading) return undefined;
+    if (jobApplicationProfileCodeSetsLoading) return undefined;
 
     if (jobApplicationProfile) {
       return mapReadableJobApplicationProfile({
@@ -118,7 +117,7 @@ export default function ProfileDetails(props: Props) {
     educationLevels,
     escoLanguages,
     escoSkills,
-    isLoading,
+    jobApplicationProfileCodeSetsLoading,
     jobApplicationProfile,
     languageSkillLevels,
     languages,
@@ -138,19 +137,16 @@ export default function ProfileDetails(props: Props) {
       closeOnEsc: false,
     });
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
   return (
     <>
-      <div className="flex flex-col gap-4 w-full">
+      <div className="flex flex-col gap-4 w-full"> 
         <DetailsExpander<{ personalProfile: PersonBasicInformation }>
           title="Personal profile"
           values={personBasicInfoMapped || {}}
           labels={PROFILE_DATA_LABELS}
           hasValues={Boolean(personBasicInformation)}
           showStatusIcons={false}
+          isLoading={personBasicInfoCodeSetsLoading}
         >
           <div className="mt-8">
             <Button onClick={() => router.push('/profile/personal-profile')}>
@@ -165,6 +161,7 @@ export default function ProfileDetails(props: Props) {
           labels={PROFILE_DATA_LABELS}
           hasValues={Boolean(jobApplicationProfile)}
           showStatusIcons={false}
+          isLoading={jobApplicationProfileCodeSetsLoading}
         >
           <div className="mt-8">
             <Button onClick={() => router.push('/profile/working-profile')}>

--- a/packages/af-shared/src/components/pages/profile/profile-details/profile-details.tsx
+++ b/packages/af-shared/src/components/pages/profile/profile-details/profile-details.tsx
@@ -1,6 +1,7 @@
-import DangerButton from '@/components/ui/danger-button';
-import DetailsExpander from '@/components/ui/details-expander/details-expander';
-import { useModal } from '@/context/modal-context';
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import { Button } from 'suomifi-ui-components';
+import type { JobApplicantProfile, PersonBasicInformation } from '@/types';
 import { PROFILE_DATA_LABELS } from '@/lib/constants';
 import {
   useCountries,
@@ -16,10 +17,9 @@ import {
   useRegions,
   useWorkPermits,
 } from '@/lib/hooks/codesets';
-import type { JobApplicantProfile, PersonBasicInformation } from '@/types';
-import { useRouter } from 'next/router';
-import { useMemo } from 'react';
-import { Button } from 'suomifi-ui-components';
+import { useModal } from '@/context/modal-context';
+import DangerButton from '@/components/ui/danger-button';
+import DetailsExpander from '@/components/ui/details-expander/details-expander';
 import ProfileDeleteConfirmation from './profile-delete-confirmation';
 import {
   mapReadableJobApplicationProfile,
@@ -139,7 +139,7 @@ export default function ProfileDetails(props: Props) {
 
   return (
     <>
-      <div className="flex flex-col gap-4 w-full"> 
+      <div className="flex flex-col gap-4 w-full">
         <DetailsExpander<{ personalProfile: PersonBasicInformation }>
           title="Personal profile"
           values={personBasicInfoMapped || {}}

--- a/packages/af-shared/src/components/ui/details-expander/details-expander.tsx
+++ b/packages/af-shared/src/components/ui/details-expander/details-expander.tsx
@@ -1,4 +1,3 @@
-import CustomHeading from '@/components/ui/custom-heading';
 import { ReactNode } from 'react';
 import { MdDone, MdOutlineInfo } from 'react-icons/md';
 import {
@@ -6,6 +5,7 @@ import {
   ExpanderContent,
   ExpanderTitleButton,
 } from 'suomifi-ui-components';
+import CustomHeading from '@/components/ui/custom-heading';
 import Loading from '../loading';
 import MultiValue from './multi-value';
 import SingleValue from './single-value';
@@ -35,8 +35,17 @@ export default function DetailsExpander<T>(props: DetailsExpanderProps<T>) {
     <Expander>
       <ExpanderTitleButton>
         <div className="flex flex-row gap-2 items-center">
-          {isLoading && (<Loading variant="small" />)}
-          <span>{title}</span>{' '}
+          <div className="flex flex-row items-center gap-2 items-start relative">
+            <span>{title}</span>
+            {isLoading && (
+              <div className="w-[24px]">
+                <div className="absolute bottom-[-10px]">
+                  <Loading variant="small" />
+                </div>
+              </div>
+            )}
+          </div>
+
           {!isLoading && typeof hasValues === 'boolean' && showStatusIcons && (
             <>
               {hasValues ? (
@@ -49,85 +58,96 @@ export default function DetailsExpander<T>(props: DetailsExpanderProps<T>) {
         </div>
       </ExpanderTitleButton>
       <ExpanderContent className="!text-base">
-        <div className="flex flex-col gap-4 mt-4">
-          {!isLoading && typeof hasValues === 'boolean' && !hasValues && (
-            <CustomHeading variant="h3" className="!text-lg">
-              No information provided.
-            </CustomHeading>
-          )}
+        {isLoading ? (
+          <div className="flex items-center justify-center py-2">
+            <Loading
+              text={`Loading ${title.toLowerCase()}...`}
+              textAlign="right"
+            />
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4 mt-4">
+              {typeof hasValues === 'boolean' && !hasValues && (
+                <CustomHeading variant="h3" className="!text-lg">
+                  No information provided.
+                </CustomHeading>
+              )}
 
-          {values !== undefined &&
-            Object.keys(values).map(dataKey => {
-              const value: any = values[dataKey as keyof typeof values];
-              const isArray = Array.isArray(value);
-              const isArrayOfObjects =
-                isArray && value.every(i => typeof i === 'object');
-              const isString =
-                typeof value === 'string' || value instanceof String;
+              {values !== undefined &&
+                Object.keys(values).map(dataKey => {
+                  const value: any = values[dataKey as keyof typeof values];
+                  const isArray = Array.isArray(value);
+                  const isArrayOfObjects =
+                    isArray && value.every(i => typeof i === 'object');
+                  const isString =
+                    typeof value === 'string' || value instanceof String;
 
-              return (
-                <div key={dataKey}>
-                  {labels[dataKey] && (
-                    <CustomHeading variant="h3" className="!text-lg">
-                      {labels[dataKey]}
-                    </CustomHeading>
-                  )}
+                  return (
+                    <div key={dataKey}>
+                      {labels[dataKey] && (
+                        <CustomHeading variant="h3" className="!text-lg">
+                          {labels[dataKey]}
+                        </CustomHeading>
+                      )}
 
-                  <div className="grid grid-cols-1 lg:grid-cols-2 mt-2 gap-4">
-                    {isArray && value.length < 1 && <span>-</span>}
+                      <div className="grid grid-cols-1 lg:grid-cols-2 mt-2 gap-4">
+                        {isArray && value.length < 1 && <span>-</span>}
 
-                    {isArrayOfObjects &&
-                      value.map((_, index: number) => (
-                        <MultiValue
-                          key={`${dataKey}-${index}`}
-                          index={index}
-                          valueObj={value[index]}
-                          labels={labels}
-                        />
-                      ))}
+                        {isArrayOfObjects &&
+                          value.map((_, index: number) => (
+                            <MultiValue
+                              key={`${dataKey}-${index}`}
+                              index={index}
+                              valueObj={value[index]}
+                              labels={labels}
+                            />
+                          ))}
 
-                    {!isArrayOfObjects && !isString && (
-                      <div>
-                        {value &&
-                          Object.keys(value).map((key, i) => {
-                            const nestedValue =
-                              value[key as keyof typeof value];
-                            const isArrayOfObjects =
-                              Array.isArray(nestedValue) &&
-                              nestedValue.every(i => typeof i === 'object');
+                        {!isArrayOfObjects && !isString && (
+                          <div>
+                            {value &&
+                              Object.keys(value).map((key, i) => {
+                                const nestedValue =
+                                  value[key as keyof typeof value];
+                                const isArrayOfObjects =
+                                  Array.isArray(nestedValue) &&
+                                  nestedValue.every(i => typeof i === 'object');
 
-                            return !isArrayOfObjects ? (
-                              <SingleValue
-                                key={i}
-                                label={labels[key] || ''}
-                                value={nestedValue as string}
-                              />
-                            ) : (
-                              <MultiValue
-                                key={i}
-                                index={i}
-                                valueObj={nestedValue}
-                                labels={labels}
-                              />
-                            );
-                          })}
+                                return !isArrayOfObjects ? (
+                                  <SingleValue
+                                    key={i}
+                                    label={labels[key] || ''}
+                                    value={nestedValue as string}
+                                  />
+                                ) : (
+                                  <MultiValue
+                                    key={i}
+                                    index={i}
+                                    valueObj={nestedValue}
+                                    labels={labels}
+                                  />
+                                );
+                              })}
+                          </div>
+                        )}
+
+                        {isString && (
+                          <SingleValue
+                            label={labels[dataKey] || ''}
+                            value={value as string}
+                          />
+                        )}
                       </div>
-                    )}
+                    </div>
+                  );
+                })}
+            </div>
 
-                    {isString && (
-                      <SingleValue
-                        label={labels[dataKey] || ''}
-                        value={value as string}
-                      />
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-        </div>
-
-        {/* render any optional children content */}
-        {children && <>{children}</>}
+            {/* render any optional children content */}
+            {children && <>{children}</>}
+          </>
+        )}
       </ExpanderContent>
     </Expander>
   );

--- a/packages/af-shared/src/components/ui/details-expander/details-expander.tsx
+++ b/packages/af-shared/src/components/ui/details-expander/details-expander.tsx
@@ -1,3 +1,4 @@
+import CustomHeading from '@/components/ui/custom-heading';
 import { ReactNode } from 'react';
 import { MdDone, MdOutlineInfo } from 'react-icons/md';
 import {
@@ -5,7 +6,7 @@ import {
   ExpanderContent,
   ExpanderTitleButton,
 } from 'suomifi-ui-components';
-import CustomHeading from '@/components/ui/custom-heading';
+import Loading from '../loading';
 import MultiValue from './multi-value';
 import SingleValue from './single-value';
 
@@ -16,6 +17,7 @@ interface DetailsExpanderProps<T> {
   values: Partial<Record<keyof T, any>> | undefined;
   labels: Record<string, any>;
   children?: ReactNode;
+  isLoading?: boolean;
 }
 
 export default function DetailsExpander<T>(props: DetailsExpanderProps<T>) {
@@ -26,14 +28,16 @@ export default function DetailsExpander<T>(props: DetailsExpanderProps<T>) {
     values,
     labels,
     children,
+    isLoading = false,
   } = props;
 
   return (
     <Expander>
       <ExpanderTitleButton>
         <div className="flex flex-row gap-2 items-center">
+          {isLoading && (<Loading variant="small" />)}
           <span>{title}</span>{' '}
-          {typeof hasValues === 'boolean' && showStatusIcons && (
+          {!isLoading && typeof hasValues === 'boolean' && showStatusIcons && (
             <>
               {hasValues ? (
                 <MdDone size={22} color="green" />
@@ -46,7 +50,7 @@ export default function DetailsExpander<T>(props: DetailsExpanderProps<T>) {
       </ExpanderTitleButton>
       <ExpanderContent className="!text-base">
         <div className="flex flex-col gap-4 mt-4">
-          {typeof hasValues === 'boolean' && !hasValues && (
+          {!isLoading && typeof hasValues === 'boolean' && !hasValues && (
             <CustomHeading variant="h3" className="!text-lg">
               No information provided.
             </CustomHeading>

--- a/packages/af-shared/src/components/ui/loading.tsx
+++ b/packages/af-shared/src/components/ui/loading.tsx
@@ -3,17 +3,23 @@ import { LoadingSpinner } from 'suomifi-ui-components';
 interface Props {
   status?: 'failed' | 'loading' | 'success';
   text?: string;
+  textAlign?: 'bottom' | 'right';
   variant?: 'normal' | 'small';
 }
 
 export default function Loading(props: Props) {
-  const { status = 'loading', text = '', variant = 'normal' } = props;
+  const {
+    status = 'loading',
+    text = '',
+    textAlign = undefined,
+    variant = 'normal',
+  } = props;
 
   return (
     <LoadingSpinner
       status={status}
       text={text}
-      textAlign="bottom"
+      textAlign={textAlign}
       variant={variant}
     />
   );


### PR DESCRIPTION
Move the profile page loading indications to the specific blocks, so user sees that something is happening when loading slower than usual.

> [!NOTE]  
> Loading sometimes seems a bit slow when loading the codeset-assets from cdn, especially when disabling cache from browser

Maybe there could be some optimization done in the actual loadings, but the simplest is to just fix the user experience.

