### PR TITLE
permissionPolicy tweak, add Strict-Transport-Security header

### DIFF
--- a/apps/af-mvp/next.config.js
+++ b/apps/af-mvp/next.config.js
@@ -39,7 +39,7 @@ const nextSafeConfig = {
     reportOnly: false,
   },
   frameOptions: 'DENY',
-  permissionsPolicy: false,
+  permissionsPolicy: !isDev ? 'none' : false,
   permissionsPolicyDirectiveSupport: ['proposed', 'standard'],
   referrerPolicy: 'no-referrer',
   xssProtection: '1; mode=block',
@@ -57,7 +57,13 @@ const nextConfig = {
     return [
       {
         source: '/:path*',
-        headers: nextSafe(nextSafeConfig),
+        headers: [
+          ...nextSafe(nextSafeConfig),
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=3571000; includeSubDomains; preload',
+          },
+        ],
       },
     ];
   },

--- a/apps/af-mvp/next.config.js
+++ b/apps/af-mvp/next.config.js
@@ -61,7 +61,7 @@ const nextConfig = {
           ...nextSafe(nextSafeConfig),
           {
             key: 'Strict-Transport-Security',
-            value: 'max-age=3571000; includeSubDomains; preload',
+            value: 'max-age=31536000; includeSubDomains; preload',
           },
         ],
       },


### PR DESCRIPTION
Tweaks:

- next-safe: tweak the `permissionPolicy` header key - set to 'none' (next-safe default) instead of false, which omits the key/header altogether
   - setting this key applies `Permissions-Policy` and `Feature-Policy` headers. Gives myriad of warnings in console though, depending on browser (use false in dev to get rid of these):
   - https://trezy.gitbook.io/next-safe/usage/troubleshooting#why-do-i-see-so-many-unrecognized-feature-warnings 

![Screenshot 2024-01-09 at 10 30 24](https://github.com/Virtual-Finland-Development/access-finland/assets/111576674/11e71e1d-0803-4b3d-9307-b6174e4ad30a)

- Add `Strict-Transport-Security` (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) in the mix with some defaults.
- max-age value (1 year) from example..

With these changes, great success:

![Screenshot 2024-01-09 at 10 26 13](https://github.com/Virtual-Finland-Development/access-finland/assets/111576674/5c109702-0879-41cc-afcf-ea733bc84ca2)
