### PR TITLE
VF Login cognito session to backend

### DIFF
--- a/apps/af-mvp/src/lib/frontend/ApiStorage.ts
+++ b/apps/af-mvp/src/lib/frontend/ApiStorage.ts
@@ -5,6 +5,7 @@ import apiClient from '@shared/lib/api/api-client';
 export class ApiStorage implements KeyValueStorageInterface {
   private apiClient: AxiosInstance;
   private endpoint: string;
+  private cache: Record<string, string> = {};
 
   constructor(endpoint: string) {
     this.endpoint = endpoint;
@@ -12,9 +13,13 @@ export class ApiStorage implements KeyValueStorageInterface {
   }
 
   async setItem(key: string, value: string): Promise<void> {
+    this.cache[key] = value;
     await this.apiClient.post(this.endpoint, { action: 'set', key, value });
   }
   async getItem(key: string): Promise<string | null> {
+    if (typeof this.cache[key] !== 'undefined') {
+      return this.cache[key];
+    }
     const response = await this.apiClient.post(this.endpoint, {
       action: 'get',
       key,
@@ -22,9 +27,11 @@ export class ApiStorage implements KeyValueStorageInterface {
     return response.data.value;
   }
   async removeItem(key: string): Promise<void> {
+    delete this.cache[key];
     await this.apiClient.post(this.endpoint, { action: 'remove', key });
   }
   async clear(): Promise<void> {
+    this.cache = {};
     await this.apiClient.post(this.endpoint, { action: 'clear' });
   }
 }

--- a/apps/af-mvp/src/lib/frontend/ApiStorage.ts
+++ b/apps/af-mvp/src/lib/frontend/ApiStorage.ts
@@ -1,0 +1,30 @@
+import { KeyValueStorageInterface } from 'aws-amplify/utils';
+import { AxiosInstance } from 'axios';
+import apiClient from '@shared/lib/api/api-client';
+
+export class ApiStorage implements KeyValueStorageInterface {
+  private apiClient: AxiosInstance;
+  private endpoint: string;
+
+  constructor(endpoint: string) {
+    this.endpoint = endpoint;
+    this.apiClient = apiClient;
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    await this.apiClient.post(this.endpoint, { action: 'set', key, value });
+  }
+  async getItem(key: string): Promise<string | null> {
+    const response = await this.apiClient.post(this.endpoint, {
+      action: 'get',
+      key,
+    });
+    return response.data.value;
+  }
+  async removeItem(key: string): Promise<void> {
+    await this.apiClient.post(this.endpoint, { action: 'remove', key });
+  }
+  async clear(): Promise<void> {
+    await this.apiClient.post(this.endpoint, { action: 'clear' });
+  }
+}

--- a/apps/af-mvp/src/lib/frontend/aws-cognito.ts
+++ b/apps/af-mvp/src/lib/frontend/aws-cognito.ts
@@ -6,7 +6,9 @@ import {
   signOut as signOutWithCognito,
   signUp as signUpWithCognito,
 } from 'aws-amplify/auth';
+import { cognitoUserPoolsTokenProvider } from 'aws-amplify/auth/cognito';
 import { randomBytes } from 'crypto';
+import { ApiStorage } from './ApiStorage';
 
 // @see: https://docs.amplify.aws/javascript/build-a-backend/auth/advanced-workflows/
 
@@ -83,6 +85,11 @@ Amplify.configure({
     },
   },
 });
+
+// @see: https://docs.amplify.aws/javascript/build-a-backend/auth/manage-user-session/
+cognitoUserPoolsTokenProvider.setKeyValueStorage(
+  new ApiStorage('/api/auth/system/session')
+);
 
 export async function fetchAuthIdToken(): Promise<string | null> {
   try {

--- a/apps/af-mvp/src/pages/api/auth/system/session.route.ts
+++ b/apps/af-mvp/src/pages/api/auth/system/session.route.ts
@@ -1,0 +1,59 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import cookie from 'cookie';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  // Parse payload
+  const { action, key, value } = req.body;
+
+  // Perform action
+  switch (action) {
+    case 'set':
+      res
+        .setHeader('Set-Cookie', [
+          cookie.serialize(key, value, {
+            path: '/api/auth/system/session',
+            httpOnly: true,
+            sameSite: 'strict',
+          }),
+        ])
+        .json({});
+      break;
+    case 'get':
+      res.json({ value: req.cookies[key] });
+      break;
+    case 'remove':
+      res
+        .setHeader('Set-Cookie', [
+          cookie.serialize(key, '', {
+            path: '/api/auth/system/session',
+            httpOnly: true,
+            sameSite: 'strict',
+            expires: new Date(0),
+          }),
+        ])
+        .json({});
+      break;
+    case 'clear':
+      const existingCookies = Object.keys(req.cookies);
+      res
+        .setHeader(
+          'Set-Cookie',
+          existingCookies.map(cookieName =>
+            cookie.serialize(cookieName, '', {
+              path: '/api/auth/system/session',
+              httpOnly: true,
+              sameSite: 'strict',
+              expires: new Date(0),
+            })
+          )
+        )
+        .json({});
+      break;
+    default:
+      res.status(400).json({ message: 'Invalid action' });
+      break;
+  }
+}

--- a/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
+++ b/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
@@ -52,8 +52,10 @@ export default function SingInPage() {
   }, [checkAuthStatus, isLoading]);
 
   const handleCognitoLogout = async () => {
+    setIsLoading(true);
     await signOut();
-    router.reload();
+    setIsAuthenticated(false);
+    setIsLoading(false);
   };
 
   if (isLoading) {

--- a/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
+++ b/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
@@ -56,6 +56,11 @@ export default function SingInPage() {
     await signOut();
     setIsAuthenticated(false);
     setIsLoading(false);
+    toast({
+      title: 'Logged out',
+      content: 'Logged out from Virtual Finland.',
+      status: 'neutral',
+    });
   };
 
   if (isLoading) {


### PR DESCRIPTION
Amplify-js oletuksena tallentaa cognito-session tiedot selaimen localStorage-ajuriin, jossa on periaatteessa XSS-vektori olemassa koska js:llä on tietoihin pääsy. Muutetaan niin että tiedot tallentuu sen sijaan backendiin keksiin.

Huom. tästä tulee hieman request-ruuhkaa `/api/auth/system/session`. Se on vähän harmi, mutta sivun luonteen vuoksi (kun tunnistautuminen tehty ei sivulla enää navigoida) ihan ok tradeoff sille että saadaan tokenit pois js:n käsistä. Tuota voisi korjata todennäköisesti vain siten että puukottelee amplifyä että voisi bulk-kyselyinä tehdä asiat -> eli lopputulemana poistaa kirjaston ja tekee ite. 