### PR TITLE
Overlay Loading component feature

### DIFF
--- a/packages/af-shared/src/components/layout/page.tsx
+++ b/packages/af-shared/src/components/layout/page.tsx
@@ -53,7 +53,7 @@ interface PageBlockProps {
 
 function PageBlock(props: PageBlockProps) {
   const { className: propsClassName = '', children } = props;
-  const className = `px-4 lg:px-16 py-5 ${propsClassName}`;
+  const className = `relative px-4 lg:px-16 py-5 ${propsClassName}`;
 
   return (
     <Block variant="section" className={className}>

--- a/packages/af-shared/src/components/pages/profile/profile-details/profile-delete-confirmation.tsx
+++ b/packages/af-shared/src/components/pages/profile/profile-details/profile-delete-confirmation.tsx
@@ -45,7 +45,7 @@ export default function ProfileDeleteConfirmation(props: Props) {
           Yes, Delete
         </DangerButton>
         {isLoading && (
-          <div className="mt-1 ml-1">
+          <div className="ml-1">
             <Loading variant="small" />
           </div>
         )}

--- a/packages/af-shared/src/components/pages/profile/tos-agreement-actions.tsx
+++ b/packages/af-shared/src/components/pages/profile/tos-agreement-actions.tsx
@@ -120,7 +120,7 @@ export default function TosAgreementActions(props: Props) {
             </DangerButton>
           )}
           {isLoading && (
-            <div className="mt-1 ml-1">
+            <div className="ml-1">
               <Loading variant="small" />
             </div>
           )}

--- a/packages/af-shared/src/components/ui/details-expander/details-expander.tsx
+++ b/packages/af-shared/src/components/ui/details-expander/details-expander.tsx
@@ -35,15 +35,9 @@ export default function DetailsExpander<T>(props: DetailsExpanderProps<T>) {
     <Expander>
       <ExpanderTitleButton>
         <div className="flex flex-row gap-2 items-center">
-          <div className="flex flex-row items-center gap-2 items-start relative">
+          <div className="flex flex-row items-center gap-2 items-start">
             <span>{title}</span>
-            {isLoading && (
-              <div className="w-[24px]">
-                <div className="absolute bottom-[-10px]">
-                  <Loading variant="small" />
-                </div>
-              </div>
-            )}
+            {isLoading && <Loading variant="small" />}
           </div>
 
           {!isLoading && typeof hasValues === 'boolean' && showStatusIcons && (

--- a/packages/af-shared/src/components/ui/loading.tsx
+++ b/packages/af-shared/src/components/ui/loading.tsx
@@ -6,7 +6,7 @@ interface Props {
   text?: string;
   textAlign?: 'bottom' | 'right';
   variant?: 'normal' | 'small';
-  /** Loading indicator will be absolute positioned and centered relative to first relative positioned container element. Add 'position: relative' to target container element when needed. */
+  /** Loading indicator will be 'absolute' positioned and centered relative to first 'relative' positioned container element. Add 'position: relative' to target container element when needed. */
   asOverlay?: boolean;
   /** Background color for the loading overlay (with see-through opacity). Defaults to '#fff'. Use valid CSS color value like HEX or RGB */
   overlayBgColor?: string;

--- a/packages/af-shared/src/components/ui/loading.tsx
+++ b/packages/af-shared/src/components/ui/loading.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { LoadingSpinner } from 'suomifi-ui-components';
 
 interface Props {
@@ -5,6 +6,10 @@ interface Props {
   text?: string;
   textAlign?: 'bottom' | 'right';
   variant?: 'normal' | 'small';
+  /** When used, loading indicator is absolute positioned relative to container element. Add 'position: relative' to container element when needed. */
+  asOverlay?: boolean;
+  /** Background color for the loading overlay. Defaults to 'white'. Use valid CSS color value like HEX, RGB or corresponding string value. */
+  overlayBgColor?: string;
 }
 
 export default function Loading(props: Props) {
@@ -13,10 +18,27 @@ export default function Loading(props: Props) {
     text = '',
     textAlign = undefined,
     variant = 'normal',
+    asOverlay = false,
+    overlayBgColor = 'white',
   } = props;
 
-  return (
+  const renderLoadingSpinner = (spinner: ReactNode) => {
+    if (asOverlay) {
+      return (
+        <div
+          className={`absolute inset-0 flex items-center justify-center bg-[${overlayBgColor}] bg-opacity-60 z-10`}
+        >
+          {spinner}
+        </div>
+      );
+    }
+
+    return spinner;
+  };
+
+  return renderLoadingSpinner(
     <LoadingSpinner
+      className="!leading-none"
       status={status}
       text={text}
       textAlign={textAlign}

--- a/packages/af-shared/src/components/ui/loading.tsx
+++ b/packages/af-shared/src/components/ui/loading.tsx
@@ -6,7 +6,7 @@ interface Props {
   text?: string;
   textAlign?: 'bottom' | 'right';
   variant?: 'normal' | 'small';
-  /** When used, loading indicator is absolute positioned relative to container element. Add 'position: relative' to container element when needed. */
+  /** When used, loading indicator is absolute positioned relative to first relative positioned container element. Add 'position: relative' to container element when needed. */
   asOverlay?: boolean;
   /** Background color for the loading overlay. Defaults to 'white'. Use valid CSS color value like HEX, RGB or corresponding string value. */
   overlayBgColor?: string;

--- a/packages/af-shared/src/components/ui/loading.tsx
+++ b/packages/af-shared/src/components/ui/loading.tsx
@@ -33,7 +33,7 @@ export default function Loading(props: Props) {
       );
     }
 
-    return spinner;
+    return <>{spinner}</>;
   };
 
   return renderLoadingSpinner(

--- a/packages/af-shared/src/components/ui/loading.tsx
+++ b/packages/af-shared/src/components/ui/loading.tsx
@@ -8,7 +8,7 @@ interface Props {
   variant?: 'normal' | 'small';
   /** Loading indicator will be absolute positioned relative to first relative positioned container element. Add 'position: relative' to target container element when needed. */
   asOverlay?: boolean;
-  /** Background color for the loading overlay (with see-through opacity). Defaults to 'white'. Use valid CSS color value like HEX, RGB or corresponding string value. */
+  /** Background color for the loading overlay (with see-through opacity). Defaults to '#fff'. Use valid CSS color value like HEX or RGB */
   overlayBgColor?: string;
 }
 
@@ -19,7 +19,7 @@ export default function Loading(props: Props) {
     textAlign = undefined,
     variant = 'normal',
     asOverlay = false,
-    overlayBgColor = 'white',
+    overlayBgColor = '#fff',
   } = props;
 
   const renderLoadingSpinner = (spinner: ReactNode) => {

--- a/packages/af-shared/src/components/ui/loading.tsx
+++ b/packages/af-shared/src/components/ui/loading.tsx
@@ -6,9 +6,9 @@ interface Props {
   text?: string;
   textAlign?: 'bottom' | 'right';
   variant?: 'normal' | 'small';
-  /** When used, loading indicator is absolute positioned relative to first relative positioned container element. Add 'position: relative' to container element when needed. */
+  /** Loading indicator will be absolute positioned relative to first relative positioned container element. Add 'position: relative' to target container element when needed. */
   asOverlay?: boolean;
-  /** Background color for the loading overlay. Defaults to 'white'. Use valid CSS color value like HEX, RGB or corresponding string value. */
+  /** Background color for the loading overlay (with see-through opacity). Defaults to 'white'. Use valid CSS color value like HEX, RGB or corresponding string value. */
   overlayBgColor?: string;
 }
 

--- a/packages/af-shared/src/components/ui/loading.tsx
+++ b/packages/af-shared/src/components/ui/loading.tsx
@@ -6,7 +6,7 @@ interface Props {
   text?: string;
   textAlign?: 'bottom' | 'right';
   variant?: 'normal' | 'small';
-  /** Loading indicator will be absolute positioned relative to first relative positioned container element. Add 'position: relative' to target container element when needed. */
+  /** Loading indicator will be absolute positioned and centered relative to first relative positioned container element. Add 'position: relative' to target container element when needed. */
   asOverlay?: boolean;
   /** Background color for the loading overlay (with see-through opacity). Defaults to '#fff'. Use valid CSS color value like HEX or RGB */
   overlayBgColor?: string;


### PR DESCRIPTION
Tuossa congito-branchilla käyteltiin ns. "overlay loading", niin siitä ajatuksena jatkoin tuota Loading komponentin tuunausta jotta vois suoriltaan yleiskäyttää:

 - `asOverlay` prop
 - `overlayBgColor` prop
 - Selitteet miten käytellä. Layoutin Page.Block on nyt relative, jolloin sen sisällä overlay loadingia voi suoriltaan käyttää. Voi myös tarkemmin targetoida.
 - pientä twiikkausta indikaattorin asemointiin, muutamassa paikkaa pyyhitty turhaa tyyliä pois kun istuu nyt paremmin