### PR TITLE
ui flow for auth id deletion, uses modal for confirmation

### DIFF
--- a/apps/af-mvp/src/lib/frontend/aws-cognito.ts
+++ b/apps/af-mvp/src/lib/frontend/aws-cognito.ts
@@ -1,6 +1,7 @@
 import { Amplify } from 'aws-amplify';
 import {
   confirmSignIn as confirmSignInWithCognito,
+  deleteUser as deleteCognitoUser,
   fetchAuthSession as fetchAuthSessionFromCognito,
   signIn as signInWithCognito,
   signOut as signOutWithCognito,
@@ -148,6 +149,10 @@ export async function confirmSignIn(code: string) {
 
 export async function signOut() {
   await signOutWithCognito();
+}
+
+export async function deleteUser() {
+  await deleteCognitoUser();
 }
 
 export function parseCognitoError(error: any): CognitoError {

--- a/apps/af-mvp/src/lib/frontend/aws-cognito.ts
+++ b/apps/af-mvp/src/lib/frontend/aws-cognito.ts
@@ -200,7 +200,7 @@ export function parseCognitoError(error: any): CognitoError {
   }
 
   return {
-    message: 'Unknown error',
+    message: (error instanceof Error ? error.message : null) ?? 'Unknown error',
     type: errorType,
   };
 }

--- a/apps/af-mvp/src/pages/_app.page.tsx
+++ b/apps/af-mvp/src/pages/_app.page.tsx
@@ -53,6 +53,14 @@ const Container = styled.div.attrs({
 
 const NoProvider = ({ children }: { children: ReactNode }) => <>{children}</>;
 
+function UiUtilsProviders({ children }: { children: ReactNode }) {
+  return (
+    <ToastProvider>
+      <ModalProvider>{children}</ModalProvider>
+    </ToastProvider>
+  );
+}
+
 export default function App({ Component, pageProps }: ExtendedAppProps) {
   const ComponentContextProvider = Component.provider || NoProvider;
   const router = useRouter();
@@ -82,24 +90,22 @@ export default function App({ Component, pageProps }: ExtendedAppProps) {
 
             if (AUTH_ROUTES.includes(router.pathname)) {
               return (
-                <ToastProvider>
+                <UiUtilsProviders>
                   <Container>
                     <Component {...pageProps} />
                   </Container>
-                </ToastProvider>
+                </UiUtilsProviders>
               );
             }
 
             return (
-              <ToastProvider>
-                <ModalProvider>
-                  <MainLayout navigationItems={NAV_ITEMS} languages={LANGUAGES}>
-                    <ComponentContextProvider>
-                      <Component {...pageProps} />
-                    </ComponentContextProvider>
-                  </MainLayout>
-                </ModalProvider>
-              </ToastProvider>
+              <UiUtilsProviders>
+                <MainLayout navigationItems={NAV_ITEMS} languages={LANGUAGES}>
+                  <ComponentContextProvider>
+                    <Component {...pageProps} />
+                  </ComponentContextProvider>
+                </MainLayout>
+              </UiUtilsProviders>
             );
           }}
         </AuthConsumer>

--- a/apps/af-mvp/src/pages/auth/sign-in/components/signed-in.tsx
+++ b/apps/af-mvp/src/pages/auth/sign-in/components/signed-in.tsx
@@ -21,7 +21,6 @@ function Confirm(props: ConfirmProps) {
   const handleDeleteClick = async () => {
     setIsLoading(true);
     await handleDelete();
-    setIsLoading(false);
     handleClose();
   };
 
@@ -66,6 +65,7 @@ export default function SignedIn(props: Props) {
     openModal({
       title: 'Delete Your Virtual Finland Identity',
       content: <Confirm handleDelete={handleDelete} handleClose={closeModal} />,
+      closeOnEsc: false,
     });
 
   return (

--- a/apps/af-mvp/src/pages/auth/sign-in/components/signed-in.tsx
+++ b/apps/af-mvp/src/pages/auth/sign-in/components/signed-in.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { Button, IconLogin, IconLogout, Text } from 'suomifi-ui-components';
+import { useModal } from '@shared/context/modal-context';
+import DangerButton from '@shared/components/ui/danger-button';
+import Loading from '@shared/components/ui/loading';
+
+interface Props {
+  handleLogin: () => void;
+  handleLogout: () => void;
+  handleDelete: () => void;
+}
+
+type ConfirmProps = Pick<Props, 'handleDelete'> & {
+  handleClose: () => void;
+};
+
+function Confirm(props: ConfirmProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const { handleDelete, handleClose } = props;
+
+  const handleDeleteClick = async () => {
+    setIsLoading(true);
+    await handleDelete();
+    setIsLoading(false);
+    handleClose();
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text>
+        You can delete your Virtual Finland identity at any time. Please note
+        that deleting your account cannot be undone.
+      </Text>
+      <Text>
+        You are using Virtual Finland account for the following services and you
+        will no longer be able to log in via Virtual Finland after deleting your
+        ID:
+      </Text>
+      <ul className="list-disc list-outside text-base ml-[17px]">
+        <li>
+          <Text>Access Finland</Text>
+        </li>
+      </ul>
+      <div className="flex flex-row gap-3 mt-3 items-center">
+        <Button variant="secondary" onClick={handleClose} disabled={isLoading}>
+          Cancel
+        </Button>
+        <DangerButton onClick={handleDeleteClick} disabled={isLoading}>
+          Delete my ID
+        </DangerButton>
+        {isLoading && (
+          <div className="ml-1">
+            <Loading variant="small" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function SignedIn(props: Props) {
+  const { handleLogin, handleLogout, handleDelete } = props;
+  const { openModal, closeModal } = useModal();
+
+  const handleConfirmDelete = () =>
+    openModal({
+      title: 'Delete Your Virtual Finland Identity',
+      content: <Confirm handleDelete={handleDelete} handleClose={closeModal} />,
+    });
+
+  return (
+    <div className="flex flex-col gap-6 h-full justify-center">
+      <div className="flex flex-col gap-6 md:grow justify-center">
+        <div className="flex flex-col gap-2">
+          <Text className="!text-base">Finish login to the Access Finland</Text>
+          <Button onClick={handleLogin} icon={<IconLogin />}>
+            Login to Access Finland
+          </Button>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Text className="!text-base">
+            Logout from your Virtual Finland login session
+          </Text>
+          <Button
+            variant="secondary"
+            onClick={handleLogout}
+            icon={<IconLogout />}
+          >
+            Log out from Virtual Finland
+          </Button>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Text className="!text-base">Delete Your Virtual Finland Identity</Text>
+        <DangerButton onClick={handleConfirmDelete} variant="secondary">
+          Delete My Virtual Finland ID
+        </DangerButton>
+      </div>
+    </div>
+  );
+}

--- a/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
+++ b/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
@@ -8,18 +8,13 @@ import {
   signOut,
 } from '@mvp/lib/frontend/aws-cognito';
 import VFLogo from '@shared/images/virtualfinland_logo_small.png';
-import {
-  Button,
-  IconHome,
-  IconLogin,
-  IconLogout,
-  Text,
-} from 'suomifi-ui-components';
+import { IconHome, Text } from 'suomifi-ui-components';
 import { useToast } from '@shared/context/toast-context';
 import CustomImage from '@shared/components/ui/custom-image';
 import CustomLink from '@shared/components/ui/custom-link';
 import Loading from '@shared/components/ui/loading';
 import SignIn from './components/sign-in';
+import SignedIn from './components/signed-in';
 
 // Create csrf token for the login form (as a ssr prop)
 export const getServerSideProps: GetServerSideProps<{
@@ -63,7 +58,12 @@ export default function SingInPage({
     });
   };
 
-  const handleAccessFinlandLoginButtonClick = async () => {
+  const handleCongnitoIdDelete = async () => {
+    console.log('Delete cognito id');
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  };
+
+  const handleAccessFinlandLogin = async () => {
     setIsLoading(true);
 
     // Login to the actual application
@@ -116,23 +116,11 @@ export default function SingInPage({
             {!isAuthenticated ? (
               <SignIn />
             ) : (
-              <div className="flex flex-col gap-6 h-full justify-center">
-                Finish login to the Access Finland
-                <Button
-                  onClick={handleAccessFinlandLoginButtonClick}
-                  icon={<IconLogin />}
-                >
-                  Login to Access Finland
-                </Button>
-                Logout from your Virtual Finland login session
-                <Button
-                  variant="secondary"
-                  onClick={handleCognitoLogout}
-                  icon={<IconLogout />}
-                >
-                  Log out from Virtual Finland
-                </Button>
-              </div>
+              <SignedIn
+                handleLogin={handleAccessFinlandLogin}
+                handleLogout={handleCognitoLogout}
+                handleDelete={handleCongnitoIdDelete}
+              />
             )}
           </div>
         </div>

--- a/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
+++ b/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
@@ -60,10 +60,10 @@ export default function SingInPage({
 
   const handleCognitoLogout = async () => {
     setIsLoading(true);
+
     try {
       await signOut();
       setIsAuthenticated(false);
-      setIsLoading(false);
       toast({
         title: 'Logged out',
         content: 'Logged out from Virtual Finland.',
@@ -71,12 +71,12 @@ export default function SingInPage({
       });
     } catch (error) {
       handleError(error);
+    } finally {
+      setIsLoading(false);
     }
-    setIsLoading(false);
   };
 
   const handleCongnitoIdDelete = async () => {
-    setIsLoading(true);
     try {
       await deleteUser();
       setIsAuthenticated(false);
@@ -88,7 +88,6 @@ export default function SingInPage({
     } catch (error) {
       handleError(error);
     }
-    setIsLoading(false);
   };
 
   const handleAccessFinlandLogin = async () => {

--- a/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
+++ b/apps/af-mvp/src/pages/auth/sign-in/index.page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { generateCSRFToken } from '@mvp/lib/backend/secrets-and-tokens';
 import {
   authStore,
+  deleteUser,
   fetchAuthIdToken,
   signOut,
 } from '@mvp/lib/frontend/aws-cognito';
@@ -59,8 +60,15 @@ export default function SingInPage({
   };
 
   const handleCongnitoIdDelete = async () => {
-    console.log('Delete cognito id');
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    setIsLoading(true);
+    await deleteUser();
+    setIsAuthenticated(false);
+    setIsLoading(false);
+    toast({
+      title: 'Identity deleted',
+      content: 'The Virtual Finland identity deleted.',
+      status: 'neutral',
+    });
   };
 
   const handleAccessFinlandLogin = async () => {

--- a/packages/af-shared/src/components/ui/danger-button.tsx
+++ b/packages/af-shared/src/components/ui/danger-button.tsx
@@ -1,28 +1,51 @@
 import styled from 'styled-components';
 import { Button } from 'suomifi-ui-components';
 
-const StyledButton = styled(Button).attrs({ variant: 'default' })`
-  ${props =>
-    props.disabled
-      ? 'background: rgb(252 165 165) !important'
-      : `background: rgb(220 38 38) !important;
-      &:hover {
-        background-color: rgb(239 68 68) !important;
-      }
-      `}
+const StyledButton = styled(Button).attrs(props => ({
+  variant: props.variant,
+}))`
+  ${({ variant }) => {
+    if (variant === 'secondary') {
+      return `
+        border-color: rgb(220 38 38) !important;
+        color: rgb(220 38 38) !important;
+        background: #FFF !important;
+        &:hover {
+          background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%) !important;
+        }
+        &:disabled {
+          border-color: hsl(202,7%,67%) !important;
+          color: hsl(202,7%,67%) !important;
+          background: hsl(212,63%,98%) !important;
+        }
+      `;
+    } else {
+      return `
+        border-color: rgb(220 38 38) !important;
+        background: rgb(220 38 38) !important;
+        &:hover {
+          background-color: rgb(239 68 68) !important;
+        }
+        &:disabled {
+          background: rgb(252 165 165) !important;
+        }
+      `;
+    }
+  }}
 `;
 
 interface Props {
   children: string;
   onClick: () => void;
   disabled?: boolean;
+  variant?: 'default' | 'secondary';
 }
 
 export default function DangerButton(props: Props) {
-  const { children, onClick, disabled = false } = props;
+  const { children, onClick, disabled = false, variant = 'default' } = props;
 
   return (
-    <StyledButton onClick={onClick} disabled={disabled}>
+    <StyledButton onClick={onClick} disabled={disabled} variant={variant}>
       {children}
     </StyledButton>
   );


### PR DESCRIPTION
Sellainen huomio tuossa, että jostain syystä nuo "log in" ja "log out" glitchailee ui:lla vähän ikävästi, loading state jotenkin hyppelee tossa. Varmaan nuo try catchit ja await noissa funkkareissa.

e: aaaah... taitaapi johtua tuosta useEffectistä, missä tuo `authStore.setCsrfToken` asetellaan. Siinä on depsinä `isLoading` ja siinä kutsutaan `checkAuthStatus`, joka myös kutsuu `setIsLoading(false)`... eli kiva pikku react-effect-ansa! En tuohon nyt koskenut, varmaan mainissa sama problm.