### PR TITLE
Fix email receiving delay on ms360

### DIFF
--- a/infra/af-mvp/resources/lambda-functions/utils/email.ts
+++ b/infra/af-mvp/resources/lambda-functions/utils/email.ts
@@ -5,7 +5,7 @@ function wrapHtmlEmailContentWithCoreStructure(
   htmlBodyContent: string
 ) {
   return `<!DOCTYPE html>
-  <html>
+<html>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,6 +14,7 @@ function wrapHtmlEmailContentWithCoreStructure(
       body {
         font-family: Arial, Helvetica, sans-serif;
         font-size: 14px;
+        line-height: 20px;
       }
     </style>
   </head>
@@ -21,7 +22,7 @@ function wrapHtmlEmailContentWithCoreStructure(
     <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="max-width: 600px;">
       <tr>
         <td>
-          ${htmlBodyContent}
+      ${htmlBodyContent}
           <hr />
           <p>This message cannot be replied to.</p>
         </td>
@@ -38,15 +39,13 @@ function wrapHtmlEmailContentWithCoreStructure(
  * @returns
  */
 function createEmailHtmlContent(secretLoginCode: string) {
-  const siteUrl = process.env.SITE_URL!;
   return wrapHtmlEmailContentWithCoreStructure(
     'Confirm your login to Virtual Finland',
     `
     <h1>Confirm your login</h1>
     <p>Confirm your login by entering the following code in the Virtual Finland service:</p>
     <p class='code-text' style='font-size: 20px; line-height: 30px; font-weight: bold;'>${secretLoginCode}</p>
-    <p>After entering the code, you can continue logging in to the Access Finland service:</p>
-    <p><a href='${siteUrl}'>${siteUrl}</a></p>
+    <p>After entering the code, you can continue logging in to the Access Finland service.</p>
     `
   );
 }

--- a/infra/af-mvp/resources/lambdaFunctions.ts
+++ b/infra/af-mvp/resources/lambdaFunctions.ts
@@ -112,7 +112,6 @@ export function createCreateAuthChallengeLambda(cdnSetup: CdnSetup) {
       variables: {
         LOG_LEVEL: 'INFO',
         SES_FROM_ADDRESS: setup.ses.fromAddress,
-        SITE_URL: cdnSetup.url,
       },
     },
     tags,


### PR DESCRIPTION
Sähköpostit joissa linkkejä joutuu ms360-tuotteissa erityis-syyniin ennen kuin viesti näkyy käyttäjän postilaatikossa ja tämä tuntuu aiheuttavan välillä pitkiäkin hidastuksia. Hidastukset eivät sovi tunnistautumisflowhin. Ehjätään (ainakin toistaiseksi) siten että jätetään kirjautumismailipohjasta linkit pois.