### PR TITLE
update actions versions to latest

### DIFF
--- a/.github/workflows/deploy-af-features.yml
+++ b/.github/workflows/deploy-af-features.yml
@@ -35,9 +35,9 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download the built artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact-${{ inputs.environment }}
           path: ./out

--- a/.github/workflows/deploy-af-mvp.yml
+++ b/.github/workflows/deploy-af-mvp.yml
@@ -32,7 +32,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure AWS credentials
         uses: Virtual-Finland-Development/infrastructure/.github/actions/configure-aws-credentials@main
         with:

--- a/.github/workflows/test-af-features.yml
+++ b/.github/workflows/test-af-features.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: App install, test
@@ -81,7 +81,7 @@ jobs:
           NEXT_PUBLIC_CODESETS_BASE_URL: ${{ steps.codesets-url.outputs.resource-output }}
       - name: Archive the build artifacts
         if: ${{ inputs.wants_artifacts }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifact-${{ inputs.environment }}
           path: apps/af-features/out

--- a/.github/workflows/test-af-mvp.yml
+++ b/.github/workflows/test-af-mvp.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: App install, test

--- a/.github/workflows/test-and-deploy-amplify.yml
+++ b/.github/workflows/test-and-deploy-amplify.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: App install, test
@@ -32,7 +32,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure AWS credentials
         uses: Virtual-Finland-Development/infrastructure/.github/actions/configure-aws-credentials@main
         with:


### PR DESCRIPTION
- update checkout / setup-node / download-artifact to latest (v4), deprecation warnings
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/