### PR TITLE
apiClient auth/token interceptor handling modification

### DIFF
--- a/apps/af-features/tsconfig.json
+++ b/apps/af-features/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "tsconfig/nextjs.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "../../packages/af-shared/axios.d.ts"
+  ],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "baseUrl": "./src",

--- a/apps/af-mvp/tsconfig.json
+++ b/apps/af-mvp/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "tsconfig/nextjs.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "../../packages/af-shared/axios.d.ts"
+  ],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "baseUrl": "./src",

--- a/packages/af-shared/axios.d.ts
+++ b/packages/af-shared/axios.d.ts
@@ -4,7 +4,7 @@ import 'axios';
  * Extend AxiosRequestConfig interface
  */
 declare module 'axios' {
-  export interface AxiosRequestConfig {
+  interface AxiosRequestConfig {
     idTokenRequired?: boolean; // tells if 'Auhtorization' with bearer idtoken is required for the request headers
     csrfTokenRequired?: boolean; // tells if 'x-csrf-token' is required for the request headers (af-mvp only)
   }

--- a/packages/af-shared/axios.d.ts
+++ b/packages/af-shared/axios.d.ts
@@ -7,5 +7,6 @@ declare module 'axios' {
   interface AxiosRequestConfig {
     idTokenRequired?: boolean; // tells if 'Auhtorization' with bearer idtoken is required for the request headers
     csrfTokenRequired?: boolean; // tells if 'x-csrf-token' is required for the request headers (af-mvp only)
+    isTraceable?: boolean; // tells if 'x-request-trace-id' can be set to the request headers (af-mvp only)
   }
 }

--- a/packages/af-shared/src/lib/api/api-client.ts
+++ b/packages/af-shared/src/lib/api/api-client.ts
@@ -53,21 +53,24 @@ let tokenExpirationAlertDisplayed = false;
 apiClient.interceptors.response.use(
   response => response,
   async error => {
-    // either no token, or it has expired
-    const hasExpired = !(await getValidAuthState()).isValid;
+    if (isAxiosError(error)) {
+      // either no token, or it has expired
+      const hasExpired = !(await getValidAuthState()).isValid;
 
-    if (
-      isAxiosError(error) &&
-      (error.config?.idTokenRequired || error.config?.csrfTokenRequired) &&
-      hasExpired
-    ) {
-      if (!tokenExpirationAlertDisplayed) {
-        tokenExpirationAlertDisplayed = true;
-        window.postMessage(REQUEST_NOT_AUTHORIZED);
+      if (
+        (error.config?.idTokenRequired || error.config?.csrfTokenRequired) &&
+        hasExpired
+      ) {
+        if (!tokenExpirationAlertDisplayed) {
+          tokenExpirationAlertDisplayed = true;
+          window.postMessage(REQUEST_NOT_AUTHORIZED);
+        }
+
+        // essentially, silence the error for token expiration cases for UI
+        return new Promise(() => {});
+      } else {
+        return Promise.reject(error);
       }
-
-      // essentially, silence the error for token expiration cases for UI
-      return new Promise(() => {});
     }
 
     return Promise.reject(error);

--- a/packages/af-shared/src/lib/api/api-client.ts
+++ b/packages/af-shared/src/lib/api/api-client.ts
@@ -21,10 +21,6 @@ apiClient.interceptors.request.use(async config => {
     if (config.idTokenRequired) {
       const idToken = (await LoginState.getLoggedInState())?.idToken;
       config.headers.Authorization = idToken ? `Bearer ${idToken}` : '';
-
-      /* if (!config.headers['x-consent-token']) {
-        config.headers['x-consent-token'] = '';
-      } */
     }
 
     // csrf token required (af-mvp)
@@ -67,10 +63,9 @@ apiClient.interceptors.response.use(
         }
 
         // essentially, silence the error for token expiration cases for UI
-        return new Promise(() => {});
-      } else {
-        return Promise.reject(error);
+        return Promise.resolve();
       }
+      return Promise.reject(error);
     }
 
     return Promise.reject(error);

--- a/packages/af-shared/src/lib/api/api-client.ts
+++ b/packages/af-shared/src/lib/api/api-client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, isAxiosError } from 'axios';
+import axios, { isAxiosError } from 'axios';
 import { REQUEST_NOT_AUTHORIZED } from '../constants';
 import { isExportedApplication } from '../utils';
 import { getValidAuthState } from '../utils/auth';

--- a/packages/af-shared/src/lib/api/api-client.ts
+++ b/packages/af-shared/src/lib/api/api-client.ts
@@ -67,6 +67,8 @@ apiClient.interceptors.response.use(
 
         // essentially, silence the error for token expiration cases for UI
         return new Promise(() => {});
+      } else {
+        return Promise.reject(error);
       }
     }
 

--- a/packages/af-shared/src/lib/api/api-client.ts
+++ b/packages/af-shared/src/lib/api/api-client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, isAxiosError } from 'axios';
+import axios, { isAxiosError } from 'axios';
 import { REQUEST_NOT_AUTHORIZED } from '../constants';
 import { isExportedApplication } from '../utils';
 import { getValidAuthState } from '../utils/auth';
@@ -6,6 +6,7 @@ import { CODESETS_BASE_URL } from './endpoints';
 import { LoginState } from './services/auth';
 
 // add custom configs (extended in axios.d.ts)
+// override defaults where needed, when using apiClient
 const apiClient = axios.create({
   idTokenRequired: false, // tells if 'Auhtorization' with bearer idtoken is required for the request headers
   csrfTokenRequired: false, // tells if 'x-csrf-token' is required for the request headers (af-mvp only)

--- a/packages/af-shared/src/lib/api/api-client.ts
+++ b/packages/af-shared/src/lib/api/api-client.ts
@@ -52,10 +52,10 @@ let tokenExpirationAlertDisplayed = false;
 apiClient.interceptors.response.use(
   response => response,
   async error => {
-    // either no token, or it has expired
-    const hasExpired = !(await getValidAuthState()).isValid;
-
     if (isAxiosError(error)) {
+      // either no token, or it has expired
+      const hasExpired = !(await getValidAuthState()).isValid;
+
       if (
         (error.config?.idTokenRequired || error.config?.csrfTokenRequired) &&
         hasExpired

--- a/packages/af-shared/src/lib/api/api-client.ts
+++ b/packages/af-shared/src/lib/api/api-client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosError, isAxiosError } from 'axios';
 import { REQUEST_NOT_AUTHORIZED } from '../constants';
 import { isExportedApplication } from '../utils';
 import { getValidAuthState } from '../utils/auth';
@@ -51,21 +51,23 @@ let tokenExpirationAlertDisplayed = false;
 
 apiClient.interceptors.response.use(
   response => response,
-  async (error: AxiosError) => {
+  async error => {
     // either no token, or it has expired
     const hasExpired = !(await getValidAuthState()).isValid;
 
-    if (
-      (error.config?.idTokenRequired || error.config?.csrfTokenRequired) &&
-      hasExpired
-    ) {
-      if (!tokenExpirationAlertDisplayed) {
-        tokenExpirationAlertDisplayed = true;
-        window.postMessage(REQUEST_NOT_AUTHORIZED);
-      }
+    if (isAxiosError(error)) {
+      if (
+        (error.config?.idTokenRequired || error.config?.csrfTokenRequired) &&
+        hasExpired
+      ) {
+        if (!tokenExpirationAlertDisplayed) {
+          tokenExpirationAlertDisplayed = true;
+          window.postMessage(REQUEST_NOT_AUTHORIZED);
+        }
 
-      // essentially, silence the error for token expiration cases for UI
-      return new Promise(() => {});
+        // essentially, silence the error for token expiration cases for UI
+        return new Promise(() => {});
+      }
     }
 
     return Promise.reject(error);

--- a/packages/af-shared/src/lib/api/axios.d.ts
+++ b/packages/af-shared/src/lib/api/axios.d.ts
@@ -1,0 +1,11 @@
+import 'axios';
+
+/**
+ * Extend AxiosRequestConfig interface
+ */
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    idTokenRequired?: boolean; // tells if 'Auhtorization' with bearer idtoken is required for the request headers
+    csrfTokenRequired?: boolean; // tells if 'x-csrf-token' is required for the request headers (af-mvp only)
+  }
+}

--- a/packages/af-shared/src/lib/api/services/codesets.ts
+++ b/packages/af-shared/src/lib/api/services/codesets.ts
@@ -16,93 +16,66 @@ import type {
 import apiClient from '../api-client';
 import { CODESETS_BASE_URL } from '../endpoints';
 
-export async function getCountries(): Promise<Country[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/ISO3166CountriesURL?filters=testbed`
+async function getCodeSetsResponse<T>(resourcePath: string): Promise<T[]> {
+  const { data } = await apiClient.get<T[]>(
+    `${CODESETS_BASE_URL}/resources/${resourcePath}`,
+    {
+      isTraceable: true,
+    }
   );
   return data;
 }
 
-export async function getCurrencies(): Promise<Currency[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/ISO4217Currencies?filters=nsg`
+export async function getCountries() {
+  return await getCodeSetsResponse<Country>(
+    'ISO3166CountriesURL?filters=testbed'
   );
-  return data;
 }
 
-export async function getLanguages(): Promise<Language[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/ISO639Languages`
-  );
-  return data;
+export async function getCurrencies() {
+  return await getCodeSetsResponse<Currency>('ISO4217Currencies?filters=nsg');
 }
 
-export async function getEscoLanguages(): Promise<EscoLanguage[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/EscoLanguages`
-  );
-  return data;
+export async function getLanguages() {
+  return await getCodeSetsResponse<Language>('ISO639Languages');
 }
 
-export async function getLanguageSkillLevels(): Promise<LanguageSkillLevel[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/LanguageSkillLevels`
-  );
-  return data;
+export async function getEscoLanguages() {
+  return await getCodeSetsResponse<EscoLanguage>(`EscoLanguages`);
 }
 
-export async function getNaceCodes(): Promise<Nace[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/SuomiFiKoodistotNace`
-  );
-  return data;
+export async function getLanguageSkillLevels() {
+  return await getCodeSetsResponse<LanguageSkillLevel>('LanguageSkillLevels');
 }
 
-export async function getEducationFields(): Promise<EducationField[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/EducationFields`
-  );
-  return data;
+export async function getNaceCodes() {
+  return await getCodeSetsResponse<Nace>('SuomiFiKoodistotNace');
 }
 
-export async function getEducationLevels(): Promise<EducationLevel[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/LevelsOfEducation`
-  );
-  return data;
+export async function getEducationFields() {
+  return await getCodeSetsResponse<EducationField>('EducationFields');
 }
 
-export async function getWorkPermits(): Promise<WorkPermit[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/WorkPermits`
-  );
-  return data;
+export async function getEducationLevels() {
+  return await getCodeSetsResponse<EducationLevel>('LevelsOfEducation');
 }
 
-export async function getRegions(): Promise<Region[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/Regions`
-  );
-  return data;
+export async function getWorkPermits() {
+  return await getCodeSetsResponse<WorkPermit>('WorkPermits');
 }
 
-export async function getMunicipalities(): Promise<Municipality[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/Municipalities`
-  );
-  return data;
+export async function getRegions() {
+  return await getCodeSetsResponse<Region>('Regions');
 }
 
-export async function getOccupationsFlat(): Promise<Occupation[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/OccupationsFlatURL`
-  );
-  return data;
+export async function getMunicipalities() {
+  return await getCodeSetsResponse<Municipality>('Municipalities');
 }
 
-export async function getEscoSkills(): Promise<EscoSkill[]> {
-  const { data } = await apiClient.get(
-    `${CODESETS_BASE_URL}/resources/Skills?locales=en`
-  );
-  return data;
+export async function getOccupationsFlat() {
+  return await getCodeSetsResponse<Occupation>('OccupationsFlatURL');
+}
+
+export async function getEscoSkills() {
+  return await getCodeSetsResponse<EscoSkill>('Skills?locales=en');
 }

--- a/packages/af-shared/src/lib/api/services/company.ts
+++ b/packages/af-shared/src/lib/api/services/company.ts
@@ -31,7 +31,7 @@ export async function getCompany(
   const { data } = await apiClient.post(
     `${PRH_MOCK_BASE_URL}/NSG/Agent/LegalEntity/NonListedCompany/Establishment_v1.0`,
     { nationalIdentifier },
-    { headers: { 'Content-Type': 'application/json' } }
+    { headers: { 'Content-Type': 'application/json' }, idTokenRequired: true }
   );
   return data;
 }
@@ -64,7 +64,8 @@ export async function saveCompany(
 ): Promise<NonListedCompany> {
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/establishment`,
-    payload
+    payload,
+    { idTokenRequired: true }
   );
   return data;
 }
@@ -75,7 +76,7 @@ export async function getBeneficialOwners(
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/beneficial-owners`,
     { nationalIdentifier },
-    { headers: { 'Content-Type': 'application/json' } }
+    { idTokenRequired: true, headers: { 'Content-Type': 'application/json' } }
   );
   return data;
 }
@@ -86,7 +87,8 @@ export async function saveBeneficialOwners(
 ): Promise<BenecifialOwners> {
   const { data } = await apiClient.post(
     `${PRH_MOCK_BASE_URL}/NSG/Agent/LegalEntity/NonListedCompany/BeneficialOwners/Write_v1.0`,
-    { nationalIdentifier, data: beneficialOwners }
+    { nationalIdentifier, data: beneficialOwners },
+    { idTokenRequired: true }
   );
   return data;
 }
@@ -97,7 +99,7 @@ export async function getSignatoryRights(
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/signatory-rights`,
     { nationalIdentifier },
-    { headers: { 'Content-Type': 'application/json' } }
+    { idTokenRequired: true, headers: { 'Content-Type': 'application/json' } }
   );
   return data;
 }
@@ -108,7 +110,8 @@ export async function saveSignatoryRights(
 ): Promise<SignatoryRights> {
   const { data } = await apiClient.post(
     `${PRH_MOCK_BASE_URL}/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights/Write_v1.0`,
-    { nationalIdentifier, data: signatoryRights }
+    { nationalIdentifier, data: signatoryRights },
+    { idTokenRequired: true }
   );
   return data;
 }

--- a/packages/af-shared/src/lib/api/services/company.ts
+++ b/packages/af-shared/src/lib/api/services/company.ts
@@ -10,7 +10,7 @@ import { getUserIdentifier } from '@/lib/utils/auth';
 import apiClient from '../api-client';
 import { PRH_MOCK_BASE_URL, TESTBED_API_BASE_URL } from '../endpoints';
 
-const dataSpaceHeaders: AxiosRequestConfig['headers'] = {
+const dataspaceHeaders: AxiosRequestConfig['headers'] = {
   'x-consent-token': '',
 };
 
@@ -70,7 +70,7 @@ export async function saveCompany(
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/establishment`,
     payload,
-    { idTokenRequired: true, headers: dataSpaceHeaders }
+    { idTokenRequired: true, headers: dataspaceHeaders }
   );
   return data;
 }
@@ -81,7 +81,7 @@ export async function getBeneficialOwners(
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/beneficial-owners`,
     { nationalIdentifier },
-    { idTokenRequired: true, headers: dataSpaceHeaders }
+    { idTokenRequired: true, headers: dataspaceHeaders }
   );
   return data;
 }
@@ -104,7 +104,7 @@ export async function getSignatoryRights(
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/signatory-rights`,
     { nationalIdentifier },
-    { idTokenRequired: true, headers: dataSpaceHeaders }
+    { idTokenRequired: true, headers: dataspaceHeaders }
   );
   return data;
 }

--- a/packages/af-shared/src/lib/api/services/company.ts
+++ b/packages/af-shared/src/lib/api/services/company.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from 'axios';
 import type {
   BenecifialOwners,
   CompanyBasicInformation,
@@ -8,6 +9,10 @@ import type {
 import { getUserIdentifier } from '@/lib/utils/auth';
 import apiClient from '../api-client';
 import { PRH_MOCK_BASE_URL, TESTBED_API_BASE_URL } from '../endpoints';
+
+const dataSpaceHeaders: AxiosRequestConfig['headers'] = {
+  'x-consent-token': '',
+};
 
 export async function getCompanies(): Promise<CompanyResponse[]> {
   const userId = await getUserIdentifier();
@@ -31,7 +36,7 @@ export async function getCompany(
   const { data } = await apiClient.post(
     `${PRH_MOCK_BASE_URL}/NSG/Agent/LegalEntity/NonListedCompany/Establishment_v1.0`,
     { nationalIdentifier },
-    { headers: { 'Content-Type': 'application/json' }, idTokenRequired: true }
+    { idTokenRequired: true }
   );
   return data;
 }
@@ -65,7 +70,7 @@ export async function saveCompany(
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/establishment`,
     payload,
-    { idTokenRequired: true }
+    { idTokenRequired: true, headers: dataSpaceHeaders }
   );
   return data;
 }
@@ -76,7 +81,7 @@ export async function getBeneficialOwners(
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/beneficial-owners`,
     { nationalIdentifier },
-    { idTokenRequired: true, headers: { 'Content-Type': 'application/json' } }
+    { idTokenRequired: true, headers: dataSpaceHeaders }
   );
   return data;
 }
@@ -99,7 +104,7 @@ export async function getSignatoryRights(
   const { data } = await apiClient.post(
     `${TESTBED_API_BASE_URL}/testbed/productizer/non-listed-company/signatory-rights`,
     { nationalIdentifier },
-    { idTokenRequired: true, headers: { 'Content-Type': 'application/json' } }
+    { idTokenRequired: true, headers: dataSpaceHeaders }
   );
   return data;
 }

--- a/packages/af-shared/src/lib/api/services/consent.ts
+++ b/packages/af-shared/src/lib/api/services/consent.ts
@@ -20,6 +20,7 @@ export async function checkConsent(
         dataSources,
       }),
       {
+        idTokenRequired: true,
         headers: {
           'Content-Type': 'application/json',
         },

--- a/packages/af-shared/src/lib/api/services/dataspace.ts
+++ b/packages/af-shared/src/lib/api/services/dataspace.ts
@@ -8,6 +8,7 @@ export function utilizeDataProduct(
 ) {
   return apiClient.post(
     `/api/dataspace/${dataProduct}${dataSource ? `?source=${dataSource}` : ''}`,
-    inputData
+    inputData,
+    { csrfTokenRequired: true }
   );
 }

--- a/packages/af-shared/src/lib/api/services/dataspace.ts
+++ b/packages/af-shared/src/lib/api/services/dataspace.ts
@@ -9,6 +9,6 @@ export function utilizeDataProduct(
   return apiClient.post(
     `/api/dataspace/${dataProduct}${dataSource ? `?source=${dataSource}` : ''}`,
     inputData,
-    { csrfTokenRequired: true }
+    { csrfTokenRequired: true, isTraceable: true }
   );
 }

--- a/packages/af-shared/src/lib/api/services/employment.ts
+++ b/packages/af-shared/src/lib/api/services/employment.ts
@@ -9,6 +9,7 @@ export async function getPersonWorkContracts(
     `${TESTBED_API_BASE_URL}/testbed/data-product/Employment/WorkContract_v0.3?source=staffpoint_demo`,
     {},
     {
+      idTokenRequired: true,
       headers: {
         'x-consent-token': consentToken,
       },
@@ -24,6 +25,7 @@ export async function getPersonIncomeTax(
     `${TESTBED_API_BASE_URL}/testbed/data-product/Employment/IncomeTax_v0.2?source=vero_demo`,
     {},
     {
+      idTokenRequired: true,
       headers: {
         'x-consent-token': consentToken,
       },

--- a/packages/af-shared/src/lib/api/services/jmf.ts
+++ b/packages/af-shared/src/lib/api/services/jmf.ts
@@ -17,6 +17,7 @@ export async function getRecommendations(
 
   const { data } = await apiClient.post(url, payload, {
     csrfTokenRequired: !isExport,
+    isTraceable: !isExport,
   });
   return data;
 }

--- a/packages/af-shared/src/lib/api/services/jmf.ts
+++ b/packages/af-shared/src/lib/api/services/jmf.ts
@@ -6,13 +6,17 @@ import { isExportedApplication } from '@/lib/utils';
 import apiClient from '../api-client';
 import { TESTBED_API_BASE_URL } from '../endpoints';
 
+const isExport = isExportedApplication();
+
 export async function getRecommendations(
   payload: JmfRecommendationsRequestPayload
 ): Promise<JmfRecommendationsResponse> {
-  const url = isExportedApplication()
+  const url = isExport
     ? `${TESTBED_API_BASE_URL}/jmf/recommendations`
     : `/api/jmf/recommendations`;
 
-  const { data } = await apiClient.post(url, payload);
+  const { data } = await apiClient.post(url, payload, {
+    csrfTokenRequired: !isExport,
+  });
   return data;
 }

--- a/packages/af-shared/src/lib/api/services/permits.ts
+++ b/packages/af-shared/src/lib/api/services/permits.ts
@@ -9,6 +9,7 @@ export async function getPersonWorkPermits(
     `${TESTBED_API_BASE_URL}/testbed/data-product/Permits/WorkPermit_v0.1?source=virtual_finland:development`,
     {},
     {
+      idTokenRequired: true,
       headers: {
         'x-consent-token': consentToken,
       },

--- a/packages/af-shared/src/lib/api/services/profile.ts
+++ b/packages/af-shared/src/lib/api/services/profile.ts
@@ -16,7 +16,7 @@ import { utilizeDataProduct } from './dataspace';
  */
 const isExport = isExportedApplication();
 
-const dataSpaceHeaders: AxiosRequestConfig['headers'] = {
+const dataspaceHeaders: AxiosRequestConfig['headers'] = {
   'x-consent-token': '',
 };
 
@@ -42,7 +42,7 @@ export async function getPersonBasicInfo(): Promise<PersonBasicInformation> {
   const method = isExport
     ? apiClient.get(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/basic-information`,
-        { idTokenRequired: true, headers: dataSpaceHeaders }
+        { idTokenRequired: true, headers: dataspaceHeaders }
       )
     : utilizeDataProduct('Person/BasicInformation');
 
@@ -57,7 +57,7 @@ export async function savePersonBasicInfo(
     ? apiClient.post(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/basic-information`,
         payload,
-        { idTokenRequired: true, headers: dataSpaceHeaders }
+        { idTokenRequired: true, headers: dataspaceHeaders }
       )
     : utilizeDataProduct('Person/BasicInformation/Write', payload);
 
@@ -69,7 +69,7 @@ export async function getJobApplicantProfile(): Promise<JobApplicantProfile> {
   const method = isExport
     ? apiClient.get(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/job-applicant-information`,
-        { idTokenRequired: true, headers: dataSpaceHeaders }
+        { idTokenRequired: true, headers: dataspaceHeaders }
       )
     : utilizeDataProduct('Person/JobApplicantProfile');
 
@@ -84,7 +84,7 @@ export async function saveJobApplicantProfile(
     ? apiClient.post(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/job-applicant-information`,
         payload,
-        { idTokenRequired: true, headers: dataSpaceHeaders }
+        { idTokenRequired: true, headers: dataspaceHeaders }
       )
     : utilizeDataProduct('Person/JobApplicantProfile/Write', payload);
 

--- a/packages/af-shared/src/lib/api/services/profile.ts
+++ b/packages/af-shared/src/lib/api/services/profile.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from 'axios';
 import {
   JobApplicantProfile,
   PersonBasicInformation,
@@ -14,6 +15,10 @@ import { utilizeDataProduct } from './dataspace';
  * API routes defined for MVP app in apps/af-mvp/src/pages/api.
  */
 const isExport = isExportedApplication();
+
+const dataSpaceHeaders: AxiosRequestConfig['headers'] = {
+  'x-consent-token': '',
+};
 
 export async function getProfileTosAgreement(): Promise<ProfileTosAgreement> {
   const { data } = await apiClient.get('/api/users-api/terms-of-service', {
@@ -37,7 +42,7 @@ export async function getPersonBasicInfo(): Promise<PersonBasicInformation> {
   const method = isExport
     ? apiClient.get(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/basic-information`,
-        { idTokenRequired: true }
+        { idTokenRequired: true, headers: dataSpaceHeaders }
       )
     : utilizeDataProduct('Person/BasicInformation');
 
@@ -52,7 +57,7 @@ export async function savePersonBasicInfo(
     ? apiClient.post(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/basic-information`,
         payload,
-        { idTokenRequired: true }
+        { idTokenRequired: true, headers: dataSpaceHeaders }
       )
     : utilizeDataProduct('Person/BasicInformation/Write', payload);
 
@@ -64,7 +69,7 @@ export async function getJobApplicantProfile(): Promise<JobApplicantProfile> {
   const method = isExport
     ? apiClient.get(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/job-applicant-information`,
-        { idTokenRequired: true }
+        { idTokenRequired: true, headers: dataSpaceHeaders }
       )
     : utilizeDataProduct('Person/JobApplicantProfile');
 
@@ -79,7 +84,7 @@ export async function saveJobApplicantProfile(
     ? apiClient.post(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/job-applicant-information`,
         payload,
-        { idTokenRequired: true }
+        { idTokenRequired: true, headers: dataSpaceHeaders }
       )
     : utilizeDataProduct('Person/JobApplicantProfile/Write', payload);
 

--- a/packages/af-shared/src/lib/api/services/profile.ts
+++ b/packages/af-shared/src/lib/api/services/profile.ts
@@ -28,7 +28,7 @@ export async function saveProfileTosAgreement(
   const { data } = await apiClient.post(
     '/api/users-api/terms-of-service',
     payload,
-    { csrfTokenRequired: true }
+    { csrfTokenRequired: true, isTraceable: true }
   );
   return data;
 }
@@ -95,6 +95,7 @@ export async function deleteProfile() {
   const { data } = await apiClient.delete(url, {
     idTokenRequired: isExport,
     csrfTokenRequired: !isExport,
+    isTraceable: !isExport,
   });
   return data;
 }

--- a/packages/af-shared/src/lib/api/services/profile.ts
+++ b/packages/af-shared/src/lib/api/services/profile.ts
@@ -16,7 +16,9 @@ import { utilizeDataProduct } from './dataspace';
 const isExport = isExportedApplication();
 
 export async function getProfileTosAgreement(): Promise<ProfileTosAgreement> {
-  const { data } = await apiClient.get('/api/users-api/terms-of-service');
+  const { data } = await apiClient.get('/api/users-api/terms-of-service', {
+    csrfTokenRequired: true,
+  });
   return data;
 }
 
@@ -25,7 +27,8 @@ export async function saveProfileTosAgreement(
 ): Promise<ProfileTosAgreement> {
   const { data } = await apiClient.post(
     '/api/users-api/terms-of-service',
-    payload
+    payload,
+    { csrfTokenRequired: true }
   );
   return data;
 }
@@ -33,7 +36,8 @@ export async function saveProfileTosAgreement(
 export async function getPersonBasicInfo(): Promise<PersonBasicInformation> {
   const method = isExport
     ? apiClient.get(
-        `${TESTBED_API_BASE_URL}/testbed/productizer/person/basic-information`
+        `${TESTBED_API_BASE_URL}/testbed/productizer/person/basic-information`,
+        { idTokenRequired: true }
       )
     : utilizeDataProduct('Person/BasicInformation');
 
@@ -47,7 +51,8 @@ export async function savePersonBasicInfo(
   const method = isExport
     ? apiClient.post(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/basic-information`,
-        payload
+        payload,
+        { idTokenRequired: true }
       )
     : utilizeDataProduct('Person/BasicInformation/Write', payload);
 
@@ -58,7 +63,8 @@ export async function savePersonBasicInfo(
 export async function getJobApplicantProfile(): Promise<JobApplicantProfile> {
   const method = isExport
     ? apiClient.get(
-        `${TESTBED_API_BASE_URL}/testbed/productizer/person/job-applicant-information`
+        `${TESTBED_API_BASE_URL}/testbed/productizer/person/job-applicant-information`,
+        { idTokenRequired: true }
       )
     : utilizeDataProduct('Person/JobApplicantProfile');
 
@@ -72,7 +78,8 @@ export async function saveJobApplicantProfile(
   const method = isExport
     ? apiClient.post(
         `${TESTBED_API_BASE_URL}/testbed/productizer/person/job-applicant-information`,
-        payload
+        payload,
+        { idTokenRequired: true }
       )
     : utilizeDataProduct('Person/JobApplicantProfile/Write', payload);
 
@@ -85,6 +92,9 @@ export async function deleteProfile() {
     ? `${TESTBED_API_BASE_URL}/users-api/user`
     : `/api/users-api/user`;
 
-  const { data } = await apiClient.delete(url);
+  const { data } = await apiClient.delete(url, {
+    idTokenRequired: isExport,
+    csrfTokenRequired: !isExport,
+  });
   return data;
 }


### PR DESCRIPTION
Parannusehdotelma apiClientille. Teki mieli kokeilla siistiä tuota "protected-urls" hässäkkää axioksen interceptoreissa. Tässä extendattu axioksen RequestConfig tyyppiä, jotta tuolle voidaan passata uudet custom-avaimet `idTokenRequired` `csrfTokenRequired` `isTraceable`. Serviisipohjaisesti voi määritellä mitä milloinkin tarvitaan, ja nyt voidaan interceptoreissa näitä tarkkailemalla tehdä temput terävät.


- benefit: ei enää käsin tarvitse tökkiä jokaista suojattua endpointia listoihin
- benefit: ei duplikointia (endpointit määritelty muuallakin)
- cons?: ei enää keskitetty paikka mistä voi suoraan nähdä, mitkä on suojattua - asia pitää konffata serviisipohjaisesti / clienttia kutsuvan pään vastuulla

Onko yleisesti selkeämpi/vaikeampi hahmottaa? Tavallaan tässä `idTokenRequired` ja `csrfTokenRequired` on mutually exclusive, ja ehkä vaikee ymmärtää että missä tapauksessa mitäkin tarvitaan (kun on sekasin features-tason ja mvp-tason logiikkaa)

Jätin vielä tuonne interceptoriin kommenttiin tuon `x-consent-token = ''` -headerin, kun ei tässä mielestäni enää ole casea missä tuo pitäisi tuputtaa tuollaisenaan (jos kutsu menee testbed-apin kautta, se taitaa lisäillä tuon siellä kyytiin?). Ei ainakaan tullut vielä tilannetta vastaan, missä olisi tuon takia stopannut. 

Tämä ei ole mikään välttämättömyys, mielestäni testasin kaiken ja pitäisi toimia. Vai tuleeko vielä ideaa miten vielä siistimpi?